### PR TITLE
Resolve actionable CodeQL findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   privacy:
     name: Privacy gate

--- a/ts/packages/proxy/src/parsers.js
+++ b/ts/packages/proxy/src/parsers.js
@@ -1625,7 +1625,12 @@ export function renderReportMarkdown(report) {
 }
 
 export function renderReportHtml(report) {
-  const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const esc = (s) => String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
   const t = report.totals || {};
   const table = (title, head, rows) => rows.length ? `
   <h2>${esc(title)}</h2>
@@ -1744,7 +1749,12 @@ export function buildMonthCard(events, { month, now = Date.now() } = {}) {
 // Renders a month card as a self-contained 1200×630 SVG (standard OG image
 // size) in the Tokimeter green theme. Pure string builder — no I/O.
 export function renderMonthCardSvg(card) {
-  const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const esc = (s) => String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
   const money = (n) => `~$${(Number(n) || 0).toFixed(2)}`;
   const tok = (n) => {
     n = Number(n) || 0;

--- a/ts/test/parsers.test.js
+++ b/ts/test/parsers.test.js
@@ -1079,14 +1079,16 @@ test('buildMonthCard: defaults to the current month and survives zero events', (
 
 test('renderMonthCardSvg: self-contained SVG with escaped names and disclaimer', () => {
   const card = buildMonthCard([
-    { ...CARD_EVENTS[0], tool: 'claude<code>&' },
+    { ...CARD_EVENTS[0], tool: `claude<code>&"'` },
     ...CARD_EVENTS.slice(1),
   ], { month: '2026-06' });
+  card.monthLabel = `June "special" <2026> & 'friends'`;
   const svg = renderMonthCardSvg(card);
   assert.ok(svg.startsWith('<svg'));
-  assert.ok(svg.includes('claude&lt;code&gt;&amp;'));
+  assert.ok(svg.includes('claude&lt;code&gt;&amp;&quot;&#39;'));
   assert.ok(!svg.includes('claude<code>'));
-  assert.ok(svg.includes('June 2026'));
+  assert.ok(svg.includes('June &quot;special&quot; &lt;2026&gt; &amp; &#39;friends&#39;'));
+  assert.ok(!svg.includes('June "special" <2026>'));
   assert.ok(svg.includes('~$7.50'));
   assert.ok(svg.includes('not a bill'));
   assert.ok(!svg.includes('href=') && !svg.includes('src=') && !svg.includes('<script'));


### PR DESCRIPTION
## Summary
- declare read-only workflow permissions
- escape quote characters in HTML and SVG output
- add regression coverage for SVG attribute escaping

## Verification
- node scripts/privacy-check.mjs --ci
- python3 tests/test_basic.py (27 passed)
- npm test (99 passed)

## CodeQL triage
The API-key digest alert is a false positive: tokens are generated with 256 bits of entropy and SHA-256 is appropriate for high-entropy identifiers. The two stdout alerts are intentional one-time delivery of a newly created token to the local operator, not application logging; the database stores only the digest.