### PR TITLE
Prepare extension for Open VSX

### DIFF
--- a/ts/packages/vscode-extension/README.md
+++ b/ts/packages/vscode-extension/README.md
@@ -35,7 +35,7 @@ Install and configure the local proxy first:
 
 ```bash
 npm install -g tokimeter
-tokimeter setup --auto
+"$(npm prefix -g)/bin/tokimeter" setup --auto
 ```
 
 Then run **Tokimeter: Show Cost Dashboard** from the Command Palette. If the

--- a/ts/packages/vscode-extension/package.json
+++ b/ts/packages/vscode-extension/package.json
@@ -104,7 +104,7 @@
   },
   "scripts": {
     "vscode:prepublish": "echo 'skip compile'",
-    "package": "npx --yes @vscode/vsce package --out tokimeter-vscode.vsix"
+    "package": "npx --yes @vscode/vsce@3.9.2 package --out tokimeter-vscode.vsix"
   },
   "devDependencies": {
     "@types/vscode": "^1.85.0"


### PR DESCRIPTION
## Summary
- use the fresh-computer-safe Tokimeter setup path in the extension README
- pin VSIX packaging to @vscode/vsce 3.9.2

## Verification
- rebuilt VSIX: 8 intended files, 24.88 KB
- archive privacy scan: clean
- public privacy/history/package gate: pass
- Python tests: 27/27
- Node tests: 99/99