### PR TITLE
Clarify VS Code terminal privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,8 +353,10 @@ Project privacy defaults to the final folder name only. Use
 `tokimeter config set cloud.projectMode off` to omit projects completely, or
 `full` to explicitly opt into full paths before the next sync.
 
-Prompts and code are never collected on any plan, on the local tool or the
-dashboard.
+Prompts and code are never stored or uploaded on any plan, by the local tool or
+the dashboard. The optional VS Code thinking-tip detector transiently checks
+local terminal output for activity markers; it never retains or transmits that
+output and can be disabled with `tokimeter.showTipsDuringWait`.
 
 ## Project structure
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,7 @@ lives, and what never leaves your machine.
 | `~/.claude/projects/*.jsonl` | Token usage metadata from Claude Code transcripts: token counts, model names, timestamps, session ids, project paths (`cwd`) | Read-only |
 | `~/.codex/sessions/*.jsonl` | Codex rollout `token_count` events: token counts, model, effort, `cwd` | Read-only |
 | Proxy traffic (opt-in) | If you enable the local proxy for API-key usage, requests to provider APIs pass through `localhost` so usage headers/bodies can be metered | Localhost only |
+| VS Code terminal activity (optional) | With thinking tips enabled, transient output chunks are checked for spinner and activity markers; contents are not retained or transmitted | In-memory only |
 
 `tokimeter report` and `tokimeter limits` use only the read-only paths — no
 proxy, no shims, no writes outside `~/.tokimeter`.
@@ -22,6 +23,9 @@ proxy, no shims, no writes outside `~/.tokimeter`.
 - **Prompt and response content is never stored.** The tracker records usage
   *metadata* only. Transcript files are parsed for their `usage` fields; the
   message text is not persisted by Tokimeter.
+- The optional VS Code thinking-tip detector does not buffer terminal output.
+  Disable `tokimeter.showTipsDuringWait` to turn off its transient activity
+  check.
 
 ## What Tokimeter sends over the network
 

--- a/ts/packages/vscode-extension/CHANGELOG.md
+++ b/ts/packages/vscode-extension/CHANGELOG.md
@@ -17,4 +17,6 @@ Initial release.
 
 Everything is read from the local Tokimeter proxy (`http://localhost:8788`).
 No prompts or code ever leave your machine — the extension only displays
-usage metadata (tokens, models, costs, project paths).
+usage metadata (tokens, models, costs, project paths). When thinking tips are
+enabled, terminal output is checked transiently for activity markers and is
+never retained.

--- a/ts/packages/vscode-extension/README.md
+++ b/ts/packages/vscode-extension/README.md
@@ -26,7 +26,10 @@ built-in AI, or closed desktop traffic by itself.
 ## Privacy
 
 Tokimeter tracks **usage metadata only**: tokens, models, costs, timestamps,
-and project paths. Prompts and code are never read, stored, or displayed. See
+and project paths. Prompts and code are never stored, displayed, or
+transmitted. When thinking tips are enabled, the extension transiently checks
+integrated-terminal output for spinner and activity markers; it does not retain
+the output. Disable `tokimeter.showTipsDuringWait` to turn off that check. See
 the project's [SECURITY.md](https://github.com/toshipepe/tokimeter/blob/main/SECURITY.md).
 
 ## First run
@@ -48,7 +51,7 @@ status bar shows "offline", run **Tokimeter: Run Local Setup** or
 | --- | --- | --- |
 | `tokimeter.proxyUrl` | `http://localhost:8788` | Where the local proxy listens |
 | `tokimeter.showStatusBar` | `true` | Show today's cost in the status bar |
-| `tokimeter.showTipsDuringWait` | `true` | Rotating local tips while AI tools think |
+| `tokimeter.showTipsDuringWait` | `true` | Rotating local tips while AI tools think; transiently checks terminal activity markers |
 | `tokimeter.tipInterval` | `5000` | Tip rotation interval (ms) |
 | `tokimeter.dailyBudget` | `0` | Daily budget in dollars for local warnings (0 = off) |
 

--- a/ts/packages/vscode-extension/package.json
+++ b/ts/packages/vscode-extension/package.json
@@ -87,7 +87,7 @@
         "tokimeter.showTipsDuringWait": {
           "type": "boolean",
           "default": true,
-          "description": "Show rotating cost tips when AI tools are thinking"
+          "description": "Show rotating cost tips when AI tools are thinking. This checks terminal output transiently for activity markers but never retains or transmits it."
         },
         "tokimeter.tipInterval": {
           "type": "number",

--- a/ts/packages/vscode-extension/src/extension.js
+++ b/ts/packages/vscode-extension/src/extension.js
@@ -418,7 +418,6 @@ async function toggleTips() {
 class WaitStateDetector {
   constructor() {
     this.thinkingState = false;
-    this.terminalBuffer = '';
     this.setup();
   }
 
@@ -428,9 +427,14 @@ class WaitStateDetector {
       return;
     }
 
-    // Monitor terminal output for AI thinking patterns
+    // Check terminal output transiently for AI thinking patterns. The event
+    // contents are never retained or transmitted.
     this.terminalSubscription = vscode.window.onDidWriteTerminalData(e => {
-      this.terminalBuffer = (this.terminalBuffer + e.data).slice(-500);
+      const config = vscode.workspace.getConfiguration('tokimeter');
+      if (!config.get('showTipsDuringWait', true)) {
+        this.thinkingState = false;
+        return;
+      }
 
       // Detect spinner patterns: ⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏
       // Or text patterns: "Thinking...", "Working...", "Generating..."


### PR DESCRIPTION
## Summary
- remove the unused 500-character terminal output buffer
- skip terminal content inspection when thinking tips are disabled
- document the transient local activity check consistently

## Verification
- `node scripts/privacy-check.mjs --ci`
- `python3 tests/test_basic.py` (27 passed)
- `cd ts && npm test` (99 passed)
- rebuilt VSIX: 8 intended files; no PII, secrets, private-service markers, or personal paths
- VSIX SHA-256: `f0eeaafd226aa872a91a806693c2411eb49ad6d6d2c7d79d6262e6fa0b9a365a`