### PR TITLE
Prepare Tokimeter 0.5.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The versioning is [semver](https://semver.org); pre-1.0, minor versions may add 
 
 ## Unreleased
 
+## 0.5.4 — 2026-07-28
+
 ### Trust and pricing
 
 - Separate verified built-in, community-feed, custom, reported, and

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -58,7 +58,7 @@
     },
     "packages/proxy": {
       "name": "tokimeter",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "bin": {
         "tm": "src/cli.js",

--- a/ts/packages/proxy/package.json
+++ b/ts/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokimeter",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Local-first usage & cost meter for AI coding agents (Claude Code, Codex, Cursor, Grok Build, Hermes, opencode, Cline, Copilot CLI). Inline status-line HUDs, zero-setup reports, 5h-window limits, budgets — no telemetry.",
   "type": "module",
   "main": "src/server.js",


### PR DESCRIPTION
## Summary

- bump the public npm CLI package and workspace lock entry from 0.5.3 to 0.5.4
- move the completed trust and pricing work into the dated 0.5.4 changelog section
- leave the Python SDK and VS Code extension versions unchanged

## Verification

- privacy CI and precommit gates passed
- Python tests: 29/29
- Node tests: 105/105
- CLI version smoke: 0.5.4
- npm dry-pack inspected: 11 files, no install or postinstall hook

This PR does not create a tag, GitHub release, npm stage, or npm publication.