### PR TITLE
Require npm 11.15 for staged publishing

### DIFF
--- a/.github/workflows/npm-staged-publish.yml
+++ b/.github/workflows/npm-staged-publish.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Require npm trusted-publishing support
         run: |
           npm --version
-          node -e "const { execFileSync } = require('node:child_process'); const parts = execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim().split('.').map(Number); const supported = parts[0] > 11 || (parts[0] === 11 && (parts[1] > 5 || (parts[1] === 5 && parts[2] >= 1))); if (!supported) throw new Error('npm 11.5.1 or newer is required for trusted publishing');"
+          node -e "const { execFileSync } = require('node:child_process'); const parts = execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim().split('.').map(Number); const supported = parts[0] > 11 || (parts[0] === 11 && (parts[1] > 15 || (parts[1] === 15 && parts[2] >= 0))); if (!supported) throw new Error('npm 11.15.0 or newer is required for staged trusted publishing');"
 
       - name: Stage package with npm trusted publishing
         working-directory: ts/packages/proxy

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -25,12 +25,14 @@ Owner setup required before first use:
 1. In npm package settings, configure the trusted publisher for this repository
    and the exact workflow filename `npm-staged-publish.yml`.
 2. Allow **stage publish only**, not live publish.
-3. Protect the `npm-staging` GitHub environment and release tags.
-4. After a reviewed version commit and tag exist, dispatch the workflow on that
-   tag, inspect the staged tarball/provenance, and approve it with 2FA only when
-   ready.
+3. Set npm Publishing access to **Require two-factor authentication and
+   disallow tokens**.
+4. Protect the `npm-staging` GitHub environment and release tags.
+5. After a reviewed version commit and tag exist, dispatch the workflow with
+   that tag selected as both the workflow ref and the `tag` input. Inspect the
+   staged tarball/provenance, and approve it with 2FA only when ready.
 
-npm documents that trusted publishing requires npm 11.5.1+ and Node 22.14+,
+npm documents that staged trusted publishing requires npm 11.15.0+ and Node 22.14+,
 uses short-lived OIDC credentials, and generates provenance automatically for
 public packages from public repositories:
 [trusted publishing](https://docs.npmjs.com/trusted-publishers/) and

--- a/ts/test/setup.test.js
+++ b/ts/test/setup.test.js
@@ -10,6 +10,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const CLI = join(HERE, '..', 'packages', 'proxy', 'src', 'cli.js');
 const PACKAGE_JSON = join(HERE, '..', 'packages', 'proxy', 'package.json');
 const STAGED_WORKFLOW = join(HERE, '..', '..', '.github', 'workflows', 'npm-staged-publish.yml');
+const RELEASE_DOC = join(HERE, '..', '..', 'docs', 'RELEASING.md');
 
 function isolatedEnv(root) {
   return {
@@ -107,5 +108,12 @@ test('npm package has no install hooks and release workflow is stage-only', () =
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /id-token: write/);
   assert.match(workflow, /npm stage publish/);
+  assert.match(workflow, /parts\[1\] > 15/);
+  assert.match(workflow, /npm 11\.15\.0 or newer is required for staged trusted publishing/);
   assert.doesNotMatch(workflow, /\bnpm publish\b/);
+
+  const releaseDoc = readFileSync(RELEASE_DOC, 'utf8');
+  assert.match(releaseDoc, /npm 11\.15\.0\+/);
+  assert.match(releaseDoc, /Require two-factor authentication and\s+disallow tokens/);
+  assert.match(releaseDoc, /workflow ref and the `tag` input/);
 });


### PR DESCRIPTION
## Summary
- require npm 11.15.0+ for staged trusted publishing
- document token-disallowed publishing access and exact tag dispatch procedure
- add regression coverage for the release-safety requirements

## Verification
- node scripts/privacy-check.mjs --ci
- python3 tests/test_basic.py (29/29)
- cd ts && npm test (105/105)
- cd ts && npm run pack:proxy:dry
- node scripts/privacy-check.mjs --precommit

The external npm package setting was also updated to require 2FA and disallow tokens. This PR does not publish, tag, or change package version 0.5.4.