### PR TITLE
docs: fix README header rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
-# <img src="favicon.svg" width="26" alt=""> Tokimeter
+<h1><img src="favicon.svg" width="36" alt="Tokimeter logo" align="absmiddle"> Tokimeter</h1>
 
 **Local-first usage and cost meter for Claude Code, Codex, Cursor, Grok Build,
 and other AI coding agents — no account, no telemetry.**
 
-[![npm version](https://img.shields.io/npm/v/tokimeter.svg)](https://www.npmjs.com/package/tokimeter)
-[![GitHub release](https://img.shields.io/github/v/release/toshipepe/tokimeter)](https://github.com/toshipepe/tokimeter/releases/latest)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Node 18+](https://img.shields.io/badge/node-18+-green.svg)](https://nodejs.org/en/download)
+[![npm version](https://img.shields.io/npm/v/tokimeter.svg)](https://www.npmjs.com/package/tokimeter) [![GitHub release](https://img.shields.io/github/v/release/toshipepe/tokimeter)](https://github.com/toshipepe/tokimeter/releases/latest) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Node 18+](https://img.shields.io/badge/node-18+-green.svg)](https://nodejs.org/en/download)
 
 [Website](https://tokimeter.com) · [Coverage](#coverage-and-data-fidelity) ·
 [How the numbers work](#honest-numbers-by-design)

--- a/ts/packages/proxy/README.md
+++ b/ts/packages/proxy/README.md
@@ -3,10 +3,7 @@
 **Local-first usage and cost meter for Claude Code, Codex, Cursor, Grok Build,
 and other AI coding agents — no account, no telemetry.**
 
-[![npm version](https://img.shields.io/npm/v/tokimeter.svg)](https://www.npmjs.com/package/tokimeter)
-[![GitHub release](https://img.shields.io/github/v/release/toshipepe/tokimeter)](https://github.com/toshipepe/tokimeter/releases/latest)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/toshipepe/tokimeter/blob/main/LICENSE)
-[![Node 18+](https://img.shields.io/badge/node-18+-green.svg)](https://nodejs.org/en/download)
+[![npm version](https://img.shields.io/npm/v/tokimeter.svg)](https://www.npmjs.com/package/tokimeter) [![GitHub release](https://img.shields.io/github/v/release/toshipepe/tokimeter)](https://github.com/toshipepe/tokimeter/releases/latest) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/toshipepe/tokimeter/blob/main/LICENSE) [![Node 18+](https://img.shields.io/badge/node-18+-green.svg)](https://nodejs.org/en/download)
 
 [Website](https://tokimeter.com) ·
 [Source](https://github.com/toshipepe/tokimeter)


### PR DESCRIPTION
## Summary
- render the logo and Tokimeter name in one HTML heading with a larger, vertically aligned logo
- keep all four trust badges on one physical Markdown row
- apply the badge-row correction to the npm README source

## Verification
- confirmed generated structure with GitHub's Markdown API: one h1 for logo/title and one paragraph for all badges
- `git diff --check`
- `node scripts/privacy-check.mjs --precommit`