### PR TITLE
docs: make README branding render inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
-<h1><img src="favicon.svg" width="36" alt="Tokimeter logo" align="absmiddle"> Tokimeter</h1>
+<h1><img src="favicon.svg" width="40" alt="Tokimeter logo" align="left" hspace="6">Tokimeter</h1>
 
 **Local-first usage and cost meter for Claude Code, Codex, Cursor, Grok Build,
 and other AI coding agents — no account, no telemetry.**
 
-[![npm version](https://img.shields.io/npm/v/tokimeter.svg)](https://www.npmjs.com/package/tokimeter) [![GitHub release](https://img.shields.io/github/v/release/toshipepe/tokimeter)](https://github.com/toshipepe/tokimeter/releases/latest) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Node 18+](https://img.shields.io/badge/node-18+-green.svg)](https://nodejs.org/en/download)
+<p>
+  <a href="https://www.npmjs.com/package/tokimeter"><img src="https://img.shields.io/npm/v/tokimeter.svg" alt="npm version" align="left" hspace="2"></a>
+  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="https://img.shields.io/github/v/release/toshipepe/tokimeter" alt="GitHub release" align="left" hspace="2"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" align="left" hspace="2"></a>
+  <a href="https://nodejs.org/en/download"><img src="https://img.shields.io/badge/node-18+-green.svg" alt="Node 18+" align="left" hspace="2"></a>
+</p>
+<br clear="left">
 
 [Website](https://tokimeter.com) · [Coverage](#coverage-and-data-fidelity) ·
 [How the numbers work](#honest-numbers-by-design)

--- a/ts/packages/proxy/README.md
+++ b/ts/packages/proxy/README.md
@@ -3,7 +3,13 @@
 **Local-first usage and cost meter for Claude Code, Codex, Cursor, Grok Build,
 and other AI coding agents — no account, no telemetry.**
 
-[![npm version](https://img.shields.io/npm/v/tokimeter.svg)](https://www.npmjs.com/package/tokimeter) [![GitHub release](https://img.shields.io/github/v/release/toshipepe/tokimeter)](https://github.com/toshipepe/tokimeter/releases/latest) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/toshipepe/tokimeter/blob/main/LICENSE) [![Node 18+](https://img.shields.io/badge/node-18+-green.svg)](https://nodejs.org/en/download)
+<p>
+  <a href="https://www.npmjs.com/package/tokimeter"><img src="https://img.shields.io/npm/v/tokimeter.svg" alt="npm version" align="left" hspace="2"></a>
+  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="https://img.shields.io/github/v/release/toshipepe/tokimeter" alt="GitHub release" align="left" hspace="2"></a>
+  <a href="https://github.com/toshipepe/tokimeter/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" align="left" hspace="2"></a>
+  <a href="https://nodejs.org/en/download"><img src="https://img.shields.io/badge/node-18+-green.svg" alt="Node 18+" align="left" hspace="2"></a>
+</p>
+<br clear="left">
 
 [Website](https://tokimeter.com) ·
 [Source](https://github.com/toshipepe/tokimeter)


### PR DESCRIPTION
## Summary
- float the larger Tokimeter mark beside the project name so GitHub renders one title row
- use GitHub-preserved image alignment attributes to keep all four dynamic badges on one row
- mirror the badge layout in the npm README source

## Verification
- visually verified the rendered branch on GitHub in dark mode at desktop width
- `git diff --check`
- `node scripts/privacy-check.mjs --precommit`