### PR TITLE
docs: balance README wordmark and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1>
   <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="358" height="40" alt="npm v0.5.4, release v0.5.4, MIT license, Node 18+" align="right" hspace="2"></a>
-  <img src="favicon.svg" width="38" alt="Tokimeter logo" align="left">Tokimeter
+  <img src="readme-wordmark.svg" width="190" height="48" alt="Tokimeter">
 </h1>
 
 **Local-first usage and cost meter for Claude Code, Codex, Cursor, Grok Build,

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 <h1>
-  <a href="https://nodejs.org/en/download"><img src="https://img.shields.io/badge/node-18+-green.svg" alt="Node 18+" align="right" hspace="2"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" align="right" hspace="2"></a>
-  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="https://img.shields.io/github/v/release/toshipepe/tokimeter" alt="GitHub release" align="right" hspace="2"></a>
-  <a href="https://www.npmjs.com/package/tokimeter"><img src="https://img.shields.io/npm/v/tokimeter.svg" alt="npm version" align="right" hspace="2"></a>
-  <img src="favicon.svg" width="40" alt="Tokimeter logo" align="left" hspace="3">Tokimeter<sub>&nbsp;</sub>
+  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="358" height="40" alt="npm v0.5.4, release v0.5.4, MIT license, Node 18+" align="right" hspace="2"></a>
+  <img src="favicon.svg" width="40" alt="Tokimeter logo" align="left" hspace="3">Tokimeter<sub><br></sub>
 </h1>
 
 **Local-first usage and cost meter for Claude Code, Codex, Cursor, Grok Build,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1>
   <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="358" height="40" alt="npm v0.5.4, release v0.5.4, MIT license, Node 18+" align="right" hspace="2"></a>
-  <img src="favicon.svg" width="40" alt="Tokimeter logo" align="left" hspace="3">Tokimeter<sub><br></sub>
+  <img src="favicon.svg" width="38" alt="Tokimeter logo" align="left">Tokimeter
 </h1>
 
 **Local-first usage and cost meter for Claude Code, Codex, Cursor, Grok Build,

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-<h1><img src="favicon.svg" width="40" alt="Tokimeter logo" align="left" hspace="6">Tokimeter</h1>
+<h1>
+  <a href="https://nodejs.org/en/download"><img src="https://img.shields.io/badge/node-18+-green.svg" alt="Node 18+" align="right" hspace="2"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" align="right" hspace="2"></a>
+  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="https://img.shields.io/github/v/release/toshipepe/tokimeter" alt="GitHub release" align="right" hspace="2"></a>
+  <a href="https://www.npmjs.com/package/tokimeter"><img src="https://img.shields.io/npm/v/tokimeter.svg" alt="npm version" align="right" hspace="2"></a>
+  <img src="favicon.svg" width="40" alt="Tokimeter logo" align="left" hspace="3">Tokimeter<sub>&nbsp;</sub>
+</h1>
 
 **Local-first usage and cost meter for Claude Code, Codex, Cursor, Grok Build,
 and other AI coding agents — no account, no telemetry.**
-
-<p>
-  <a href="https://www.npmjs.com/package/tokimeter"><img src="https://img.shields.io/npm/v/tokimeter.svg" alt="npm version" align="left" hspace="2"></a>
-  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="https://img.shields.io/github/v/release/toshipepe/tokimeter" alt="GitHub release" align="left" hspace="2"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" align="left" hspace="2"></a>
-  <a href="https://nodejs.org/en/download"><img src="https://img.shields.io/badge/node-18+-green.svg" alt="Node 18+" align="left" hspace="2"></a>
-</p>
-<br clear="left">
 
 [Website](https://tokimeter.com) · [Coverage](#coverage-and-data-fidelity) ·
 [How the numbers work](#honest-numbers-by-design)

--- a/readme-badges.svg
+++ b/readme-badges.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="358" height="40" viewBox="0 0 358 40" role="img" aria-label="npm v0.5.4, release v0.5.4, MIT license, Node 18+">
+  <title>npm v0.5.4 · release v0.5.4 · MIT · Node 18+</title>
+  <defs>
+    <clipPath id="npm">
+      <rect x="0" y="10" width="82" height="20" rx="3"/>
+    </clipPath>
+    <clipPath id="release">
+      <rect x="90" y="10" width="98" height="20" rx="3"/>
+    </clipPath>
+    <clipPath id="license">
+      <rect x="196" y="10" width="82" height="20" rx="3"/>
+    </clipPath>
+    <clipPath id="node">
+      <rect x="286" y="10" width="72" height="20" rx="3"/>
+    </clipPath>
+  </defs>
+
+  <g clip-path="url(#npm)">
+    <rect x="0" y="10" width="36" height="20" fill="#555"/>
+    <rect x="36" y="10" width="46" height="20" fill="#e76f51"/>
+  </g>
+  <g clip-path="url(#release)">
+    <rect x="90" y="10" width="52" height="20" fill="#555"/>
+    <rect x="142" y="10" width="46" height="20" fill="#e76f51"/>
+  </g>
+  <g clip-path="url(#license)">
+    <rect x="196" y="10" width="48" height="20" fill="#555"/>
+    <rect x="244" y="10" width="34" height="20" fill="#d4aa00"/>
+  </g>
+  <g clip-path="url(#node)">
+    <rect x="286" y="10" width="38" height="20" fill="#555"/>
+    <rect x="324" y="10" width="34" height="20" fill="#4c9a22"/>
+  </g>
+
+  <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+    <text x="18" y="24" text-anchor="middle">npm</text>
+    <text x="59" y="24" text-anchor="middle">v0.5.4</text>
+    <text x="116" y="24" text-anchor="middle">release</text>
+    <text x="165" y="24" text-anchor="middle">v0.5.4</text>
+    <text x="220" y="24" text-anchor="middle">License</text>
+    <text x="261" y="24" text-anchor="middle">MIT</text>
+    <text x="305" y="24" text-anchor="middle">node</text>
+    <text x="341" y="24" text-anchor="middle">18+</text>
+  </g>
+</svg>

--- a/readme-badges.svg
+++ b/readme-badges.svg
@@ -2,44 +2,44 @@
   <title>npm v0.5.4 · release v0.5.4 · MIT · Node 18+</title>
   <defs>
     <clipPath id="npm">
-      <rect x="0" y="10" width="82" height="20" rx="3"/>
+      <rect x="0" y="12" width="82" height="20" rx="3"/>
     </clipPath>
     <clipPath id="release">
-      <rect x="90" y="10" width="98" height="20" rx="3"/>
+      <rect x="90" y="12" width="98" height="20" rx="3"/>
     </clipPath>
     <clipPath id="license">
-      <rect x="196" y="10" width="82" height="20" rx="3"/>
+      <rect x="196" y="12" width="82" height="20" rx="3"/>
     </clipPath>
     <clipPath id="node">
-      <rect x="286" y="10" width="72" height="20" rx="3"/>
+      <rect x="286" y="12" width="72" height="20" rx="3"/>
     </clipPath>
   </defs>
 
   <g clip-path="url(#npm)">
-    <rect x="0" y="10" width="36" height="20" fill="#555"/>
-    <rect x="36" y="10" width="46" height="20" fill="#e76f51"/>
+    <rect x="0" y="12" width="36" height="20" fill="#555"/>
+    <rect x="36" y="12" width="46" height="20" fill="#e76f51"/>
   </g>
   <g clip-path="url(#release)">
-    <rect x="90" y="10" width="52" height="20" fill="#555"/>
-    <rect x="142" y="10" width="46" height="20" fill="#e76f51"/>
+    <rect x="90" y="12" width="52" height="20" fill="#555"/>
+    <rect x="142" y="12" width="46" height="20" fill="#e76f51"/>
   </g>
   <g clip-path="url(#license)">
-    <rect x="196" y="10" width="48" height="20" fill="#555"/>
-    <rect x="244" y="10" width="34" height="20" fill="#d4aa00"/>
+    <rect x="196" y="12" width="48" height="20" fill="#555"/>
+    <rect x="244" y="12" width="34" height="20" fill="#d4aa00"/>
   </g>
   <g clip-path="url(#node)">
-    <rect x="286" y="10" width="38" height="20" fill="#555"/>
-    <rect x="324" y="10" width="34" height="20" fill="#4c9a22"/>
+    <rect x="286" y="12" width="38" height="20" fill="#555"/>
+    <rect x="324" y="12" width="34" height="20" fill="#4c9a22"/>
   </g>
 
   <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
-    <text x="18" y="24" text-anchor="middle">npm</text>
-    <text x="59" y="24" text-anchor="middle">v0.5.4</text>
-    <text x="116" y="24" text-anchor="middle">release</text>
-    <text x="165" y="24" text-anchor="middle">v0.5.4</text>
-    <text x="220" y="24" text-anchor="middle">License</text>
-    <text x="261" y="24" text-anchor="middle">MIT</text>
-    <text x="305" y="24" text-anchor="middle">node</text>
-    <text x="341" y="24" text-anchor="middle">18+</text>
+    <text x="18" y="26" text-anchor="middle">npm</text>
+    <text x="59" y="26" text-anchor="middle">v0.5.4</text>
+    <text x="116" y="26" text-anchor="middle">release</text>
+    <text x="165" y="26" text-anchor="middle">v0.5.4</text>
+    <text x="220" y="26" text-anchor="middle">License</text>
+    <text x="261" y="26" text-anchor="middle">MIT</text>
+    <text x="305" y="26" text-anchor="middle">node</text>
+    <text x="341" y="26" text-anchor="middle">18+</text>
   </g>
 </svg>

--- a/readme-wordmark.svg
+++ b/readme-wordmark.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="190" height="48" viewBox="0 0 190 48" role="img" aria-label="Tokimeter">
+  <title>Tokimeter</title>
+  <style>
+    .word { fill: #1f2328; }
+    @media (prefers-color-scheme: dark) {
+      .word { fill: #f0f6fc; }
+    }
+  </style>
+
+  <g transform="translate(0 3) scale(.59375)">
+    <path d="M15 49 A24 24 0 1 1 49 49" fill="none" stroke="#4ade80" stroke-width="9.5" stroke-linecap="round"/>
+    <circle cx="32" cy="56" r="5" fill="#4ade80"/>
+    <line x1="32" y1="32" x2="43.5" y2="20.5" stroke="#4ade80" stroke-width="6" stroke-linecap="round"/>
+    <circle cx="32" cy="32" r="6.5" fill="#4ade80"/>
+  </g>
+
+  <text class="word" x="48" y="34" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="30" font-weight="600" letter-spacing="-.3">Tokimeter</text>
+</svg>


### PR DESCRIPTION
## Summary
- tighten the optical gap between the Tokimeter mark and wordmark
- move the badges into the same header row and align them to the far right
- vertically center the badge strip against the logo and title
- add more breathing room before the underline

## Implementation
GitHub currently forces individual README images into block layout and strips positioning CSS. Two small local SVG assets make this layout deterministic in light and dark modes.

## Verification
- visually verified the actual GitHub Preview at desktop width in dark mode
- `git diff --check origin/main...HEAD`
- `node scripts/privacy-check.mjs --precommit`