### PR TITLE
Fix large cloud reconnect backfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,14 +376,20 @@ CSV is the hosted multi-member allocation export.
 To connect the hosted dashboard, sign in at
 [tokimeter.com/app](https://tokimeter.com/app), choose **Connect this device**,
 and paste its one-time `tokimeter connect tmc_...` command into a terminal.
-Tokimeter backfills 30 days and then syncs new metadata from every supported
-local reader in the background. `tokimeter sync --days=30` requests a manual
-backfill, and connected devices can be revoked from the dashboard.
-Failed uploads retry with bounded exponential backoff. An expired trial or
-revoked device key pauses background retries so Tokimeter does not repeatedly
-call the hosted service; `tokimeter sync` performs an immediate reactivation
-check after an upgrade. `tokimeter doctor` shows the cloud state plus pending
-and dropped cloud-event counts without opening local state files.
+A first connection backfills 30 days and then syncs new metadata from every
+supported local reader in the background. A reconnect continues from the last
+successful local sync instead of restarting that full backfill.
+`tokimeter sync --days=30` requests a manual backfill. Large replays send recent
+activity first and resume across bounded ingest windows; already-stored event
+IDs do not consume the new-event allowance. Connected devices can be filtered
+or revoked from the dashboard, while older history created before device
+attribution appears as legacy/unassigned.
+
+Failed background uploads retry with bounded exponential backoff. An expired
+trial or revoked device key pauses background retries so Tokimeter does not
+repeatedly call the hosted service; `tokimeter sync` performs an immediate
+reactivation check after an upgrade. `tokimeter doctor` shows the cloud state
+plus pending and dropped cloud-event counts without opening local state files.
 
 Project privacy defaults to the final folder name only. Use
 `tokimeter config set cloud.projectMode off` to omit projects completely, or

--- a/ts/packages/proxy/src/cli.js
+++ b/ts/packages/proxy/src/cli.js
@@ -36,6 +36,8 @@ import {
   cloudPauseState,
   cloudResponseResult,
   eventToCloudPayload,
+  newestFirstCloudEvents,
+  sendCloudBatchWithRetry,
 } from './cloud-sync.js';
 
 const {
@@ -2823,15 +2825,25 @@ async function runCloudSync(syncArgs = [], { afterConnect = false } = {}) {
       : 2 * 86400 * 1000;
   const projectMode = cloudProjectMode(syncArgs);
   const events = collectLocalUsageEvents({ maxAgeMs });
-  const payloads = events.map((event) => eventToCloudPayload(event, { projectMode }));
+  // Replays prioritize current activity. If a large backfill is interrupted,
+  // the dashboard still catches up from newest to oldest on the next scan.
+  const payloads = newestFirstCloudEvents(events)
+    .map((event) => eventToCloudPayload(event, { projectMode }));
   const batches = chunkCloudEvents(payloads, 200);
   let sent = 0;
   try {
     for (const batch of batches) {
-      const result = await fetchCloudJson(cloudEventsUrl(cloudUrl), {
+      const result = await sendCloudBatchWithRetry(() => fetchCloudJson(cloudEventsUrl(cloudUrl), {
         apiKey: cloudKey,
         body: { contract_version: 1, events: batch },
         timeoutMs: 30000,
+      }), {
+        // Interactive sync/connect can finish a large backfill across quota
+        // windows. Background scans return promptly and resume newest-first.
+        maxQuotaRetries: quiet ? 0 : 10,
+        onQuotaWait: quiet ? null : (waitMs) => {
+          console.log(`  Cloud ingest is catching up; resuming in ${Math.ceil(waitMs / 1000)}s…`);
+        },
       });
       sent += Number(result.accepted ?? batch.length);
     }
@@ -2899,7 +2911,10 @@ async function runConnect(connectArgs) {
   console.log(`  ✓ Connected${result.device?.name ? ` as ${result.device.name}` : ''}`);
   console.log('    Only usage metadata syncs. Prompts, responses, code, account identity, and full paths are excluded.');
 
-  await runCloudSync(['--days=30'], { afterConnect: true });
+  // A reconnect continues from the last successful local cursor. A genuinely
+  // new installation still receives the documented 30-day first backfill.
+  const priorSync = readCloudSyncState();
+  await runCloudSync(Number(priorSync.lastSuccessAt) > 0 ? [] : ['--days=30'], { afterConnect: true });
   if (!connectArgs.includes('--no-restart')) {
     await stopProxy();
     await sleep(300);

--- a/ts/packages/proxy/src/cloud-sync.js
+++ b/ts/packages/proxy/src/cloud-sync.js
@@ -81,17 +81,54 @@ export function chunkCloudEvents(events, size = 200) {
   return chunks;
 }
 
+export function newestFirstCloudEvents(events) {
+  return Array.from(events || []).sort(
+    (left, right) => (Number(right?.timestamp) || 0) - (Number(left?.timestamp) || 0),
+  );
+}
+
+export async function sendCloudBatchWithRetry(send, {
+  maxQuotaRetries = 0,
+  wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  onQuotaWait = null,
+} = {}) {
+  let quotaRetries = 0;
+  while (true) {
+    try {
+      return await send();
+    } catch (error) {
+      const rateLimited = error?.rateLimited === true || Number(error?.status) === 429;
+      if (!rateLimited || quotaRetries >= maxQuotaRetries) throw error;
+      quotaRetries += 1;
+      const requestedWait = Number(error?.retryAfterMs);
+      const waitMs = Math.max(
+        1000,
+        Math.min(120000, Number.isFinite(requestedWait) && requestedWait > 0 ? requestedWait : 61000),
+      );
+      if (typeof onQuotaWait === 'function') onQuotaWait(waitMs, quotaRetries);
+      await wait(waitMs);
+    }
+  }
+}
+
 export function cloudResponseResult(status, payload = {}) {
-  const code = String(payload?.code || (Number(status) === 401 ? 'device_key_invalid' : ''));
+  const numericStatus = Number(status) || 0;
+  const rateLimited = numericStatus === 429;
+  const code = String(payload?.code || (numericStatus === 401 ? 'device_key_invalid' : rateLimited ? 'ingest_rate_limited' : ''));
   const accessPaused = Number(status) === 402 && ['trial_expired', 'upgrade_required'].includes(code);
-  const terminalFailure = accessPaused || Number(status) === 401;
+  const terminalFailure = accessPaused || numericStatus === 401;
+  const retryAfterSeconds = Number(payload?.retry_after_seconds);
   return {
-    ok: Number(status) >= 200 && Number(status) < 300,
-    status: Number(status) || 0,
+    ok: numericStatus >= 200 && numericStatus < 300,
+    status: numericStatus,
     code,
     error: String(payload?.error || ''),
     accessPaused,
     terminalFailure,
+    rateLimited,
+    retryAfterMs: rateLimited
+      ? Math.max(1000, (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0 ? retryAfterSeconds : 61) * 1000)
+      : 0,
     dataExpiresAt: payload?.data_expires_at || null,
     cloudDataDeletedAt: payload?.cloud_data_deleted_at || null,
     upgradeUrl: payload?.upgrade_url || 'https://tokimeter.com/app/',

--- a/ts/test/cloud-connect.test.js
+++ b/ts/test/cloud-connect.test.js
@@ -92,3 +92,79 @@ test('connect exchanges a one-time code, protects the key, and backfills metadat
   assert.equal(received[1].payload.events[0].project, 'private-project');
   assert.equal(received[1].payload.events[0].prompt, undefined);
 });
+
+test('reconnect continues from the last successful local sync cursor', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'tokimeter-reconnect-'));
+  t.after(async () => rm(root, { recursive: true, force: true }));
+  await chmod(root, 0o700);
+  const privateKey = 'tmk_live_reconnect-secret-never-print';
+  const received = [];
+  const server = http.createServer(async (req, res) => {
+    let body = '';
+    for await (const chunk of req) body += chunk;
+    const payload = JSON.parse(body || '{}');
+    received.push({ path: req.url, payload });
+    res.setHeader('Content-Type', 'application/json');
+    if (payload.action === 'exchange') {
+      res.end(JSON.stringify({
+        api_key: privateKey,
+        ingest_url: `http://127.0.0.1:${server.address().port}/ingest`,
+        device: { name: 'Reconnected Mac' },
+      }));
+      return;
+    }
+    res.statusCode = 201;
+    res.end(JSON.stringify({ ok: true, accepted: payload.events?.length || 0 }));
+  });
+  await new Promise((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+  t.after(() => new Promise((resolveClose) => server.close(resolveClose)));
+
+  const now = Date.now();
+  await writeFile(join(root, 'calls.jsonl'), [
+    {
+      externalId: 'already-synced-old-event',
+      timestamp: now - 20 * 86400 * 1000,
+      provider: 'openai',
+      model: 'gpt-test',
+      tool: 'codex',
+      inputTokens: 10,
+    },
+    {
+      externalId: 'missing-recent-event',
+      timestamp: now - 86400 * 1000,
+      provider: 'openai',
+      model: 'gpt-test',
+      tool: 'codex',
+      inputTokens: 20,
+    },
+  ].map((event) => JSON.stringify(event)).join('\n') + '\n');
+  await writeFile(join(root, 'cloud-sync-state.json'), JSON.stringify({
+    lastSuccessAt: now - 2 * 86400 * 1000,
+  }) + '\n');
+
+  const env = {
+    ...process.env,
+    HOME: root,
+    TOKIMETER_DATA_DIR: root,
+    CODEX_HOME: join(root, 'codex'),
+    CLAUDE_HOME: join(root, 'claude'),
+    GROK_HOME: join(root, 'grok'),
+    HERMES_HOME: join(root, 'hermes'),
+    CURSOR_HOME: join(root, 'cursor'),
+    OPENCODE_DATA_DIR: join(root, 'opencode'),
+    CLINE_DATA_DIR: join(root, 'cline'),
+  };
+  await execFileAsync(process.execPath, [
+    cliPath,
+    'connect',
+    'tmc_abcdefghijklmnopqrstuvwxyz654321',
+    `--url=http://127.0.0.1:${server.address().port}/device-connect`,
+    '--no-restart',
+  ], { env });
+
+  assert.equal(received.length, 2);
+  assert.deepEqual(
+    received[1].payload.events.map((event) => event.external_id),
+    ['missing-recent-event'],
+  );
+});

--- a/ts/test/cloud-sync.test.js
+++ b/ts/test/cloud-sync.test.js
@@ -8,7 +8,9 @@ import {
   cloudResponseResult,
   eventToCloudPayload,
   hashedSessionId,
+  newestFirstCloudEvents,
   projectForCloud,
+  sendCloudBatchWithRetry,
   stableCloudEventId,
 } from '../packages/proxy/src/cloud-sync.js';
 
@@ -59,6 +61,50 @@ test('cloud sync: batches never exceed the backend maximum', () => {
   assert.deepEqual(chunks.map((chunk) => chunk.length), [250, 250, 1]);
 });
 
+test('cloud sync: reconnect backfills send newest metadata first', () => {
+  const ordered = newestFirstCloudEvents([
+    { externalId: 'oldest', timestamp: 100 },
+    { externalId: 'newest', timestamp: 300 },
+    { externalId: 'middle', timestamp: 200 },
+  ]);
+  assert.deepEqual(ordered.map((event) => event.externalId), ['newest', 'middle', 'oldest']);
+});
+
+test('cloud sync: a foreground quota response waits and resumes the same batch', async () => {
+  let attempts = 0;
+  const waits = [];
+  const result = await sendCloudBatchWithRetry(async () => {
+    attempts += 1;
+    if (attempts === 1) {
+      throw Object.assign(new Error('Ingest rate limit exceeded'), {
+        status: 429,
+        rateLimited: true,
+        retryAfterMs: 1250,
+      });
+    }
+    return { accepted: 3 };
+  }, {
+    maxQuotaRetries: 2,
+    wait: async (milliseconds) => { waits.push(milliseconds); },
+  });
+  assert.deepEqual(result, { accepted: 3 });
+  assert.equal(attempts, 2);
+  assert.deepEqual(waits, [1250]);
+});
+
+test('cloud sync: background quota responses return promptly for the next scan', async () => {
+  await assert.rejects(
+    sendCloudBatchWithRetry(async () => {
+      throw Object.assign(new Error('Ingest rate limit exceeded'), {
+        status: 429,
+        rateLimited: true,
+        retryAfterMs: 60000,
+      });
+    }, { maxQuotaRetries: 0 }),
+    /Ingest rate limit exceeded/,
+  );
+});
+
 test('cloud sync: trial expiry becomes a durable pause instead of a retryable failure', () => {
   const result = cloudResponseResult(402, {
     code: 'trial_expired',
@@ -79,6 +125,16 @@ test('cloud sync: trial expiry becomes a durable pause instead of a retryable fa
 test('cloud sync: unrelated payment-required responses are not treated as a trial pause', () => {
   assert.equal(cloudResponseResult(402, { code: 'card_required' }).accessPaused, false);
   assert.equal(cloudResponseResult(503, { code: 'entitlement_unavailable' }).accessPaused, false);
+});
+
+test('cloud sync: Tokimeter quota responses preserve the retry delay', () => {
+  const result = cloudResponseResult(429, {
+    code: 'ingest_rate_limited',
+    error: 'Ingest rate limit exceeded',
+    retry_after_seconds: 17,
+  });
+  assert.equal(result.rateLimited, true);
+  assert.equal(result.retryAfterMs, 17000);
 });
 
 test('cloud sync: a deleted or revoked device key is terminal and does not enter the retry queue', () => {


### PR DESCRIPTION
## Summary
- resume reconnects from the saved sync cursor and send newest events first
- retry foreground syncs across bounded hosted ingest windows
- document duplicate-free replays and device attribution behavior

## Verification
- node scripts/privacy-check.mjs --ci
- python3 tests/test_basic.py
- cd ts && npm test