### PR TITLE
Prepare npm 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The versioning is [semver](https://semver.org); pre-1.0, minor versions may add 
 
 ## Unreleased
 
+## 0.5.5 — 2026-07-31
+
+### Fixed
+
+- Resume a reconnected hosted dashboard from the last successful local sync
+  instead of restarting the complete first-connection backfill.
+- Send recent metadata first during a large manual replay so the dashboard
+  catches up with current activity before older history.
+- Honor the hosted ingest retry delay during an interactive sync and resume the
+  same batch automatically across bounded quota windows.
+
 ## 0.5.4 — 2026-07-28
 
 ### Trust and pricing

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>
-  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="358" height="40" alt="npm v0.5.4, release v0.5.4, MIT license, Node 18+" align="right" hspace="2"></a>
+  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="358" height="40" alt="npm v0.5.5, release v0.5.4, MIT license, Node 18+" align="right" hspace="2"></a>
   <img src="readme-wordmark.svg" width="190" height="48" alt="Tokimeter">
 </h1>
 

--- a/readme-badges.svg
+++ b/readme-badges.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="358" height="40" viewBox="0 0 358 40" role="img" aria-label="npm v0.5.4, release v0.5.4, MIT license, Node 18+">
-  <title>npm v0.5.4 · release v0.5.4 · MIT · Node 18+</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="358" height="40" viewBox="0 0 358 40" role="img" aria-label="npm v0.5.5, release v0.5.4, MIT license, Node 18+">
+  <title>npm v0.5.5 · release v0.5.4 · MIT · Node 18+</title>
   <defs>
     <clipPath id="npm">
       <rect x="0" y="12" width="82" height="20" rx="3"/>
@@ -34,7 +34,7 @@
 
   <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
     <text x="18" y="26" text-anchor="middle">npm</text>
-    <text x="59" y="26" text-anchor="middle">v0.5.4</text>
+    <text x="59" y="26" text-anchor="middle">v0.5.5</text>
     <text x="116" y="26" text-anchor="middle">release</text>
     <text x="165" y="26" text-anchor="middle">v0.5.4</text>
     <text x="220" y="26" text-anchor="middle">License</text>

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -58,7 +58,7 @@
     },
     "packages/proxy": {
       "name": "tokimeter",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "MIT",
       "bin": {
         "tm": "src/cli.js",

--- a/ts/packages/proxy/package.json
+++ b/ts/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokimeter",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Local-first usage & cost meter for AI coding agents (Claude Code, Codex, Cursor, Grok Build, Hermes, opencode, Cline, Copilot CLI). Inline status-line HUDs, zero-setup reports, 5h-window limits, budgets — no telemetry.",
   "type": "module",
   "main": "src/server.js",


### PR DESCRIPTION
## Summary
- bump the Tokimeter CLI package and lockfile to 0.5.5
- document reconnect/backfill fixes in the changelog
- update only the npm badge; GitHub Release remains 0.5.4

## Verification
- npm run release:check
- python3 tests/test_basic.py
- tokimeter@0.5.5 confirmed unused on npm
- exact 11-file tarball passed the privacy gate