### PR TITLE
Add Copilot rollout parser fixture and tests

### DIFF
--- a/ts/test/fixtures/copilot-rollout.jsonl
+++ b/ts/test/fixtures/copilot-rollout.jsonl
@@ -1,0 +1,9 @@
+{"type":"span","traceId":"trace-chat-1","spanId":"span-chat-1","name":"chat auto","startTime":"2026-07-08T11:00:00.000Z","endTime":"2026-07-08T11:00:05.000Z","attributes":{"gen_ai.operation.name":"chat","gen_ai.request.model":"auto","gen_ai.response.model":"gpt-5.5","gen_ai.response.id":"response-1","gen_ai.conversation.id":"conversation-1","gen_ai.usage.input_tokens":1500,"gen_ai.usage.cache_read.input_tokens":300,"gen_ai.usage.output_tokens":120,"gen_ai.usage.reasoning.output_tokens":40}}
+
+{"type":"span","traceId":"trace-chat-1","spanId":"span-agent-1","parentSpanId":"span-chat-1","name":"invoke_agent auto","startTime":"2026-07-08T11:00:00.000Z","endTime":"2026-07-08T11:00:06.000Z","attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.response.model":"gpt-5.5","gen_ai.response.id":"response-1","gen_ai.conversation.id":"conversation-1","gen_ai.usage.input_tokens":1500,"gen_ai.usage.output_tokens":120,"gen_ai.usage.reasoning.output_tokens":40}}
+
+{"type":"span","traceId":"trace-chat-2","spanId":"span-chat-2","name":"chat auto","startTime":"2026-07-08T11:02:00.000Z","endTime":"2026-07-08T11:02:04.000Z","attributes":{"gen_ai.operation.name":"chat","gen_ai.request.model":"auto","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"response-2","gen_ai.conversation.id":"conversation-2","gen_ai.usage.input_tokens":500,"gen_ai.usage.output_tokens":100}}
+
+garbage line
+
+{"type":"span","traceId":"trace-ignore","spanId":"ignored","name":"database query","startTime":"2026-07-08T11:03:00.000Z","endTime":"2026-07-08T11:03:01.000Z","attributes":{"service.name":"github-copilot"}}

--- a/ts/test/parsers.test.js
+++ b/ts/test/parsers.test.js
@@ -8,6 +8,7 @@ import {
   readClaudeUsageEvents,
   readCodexTokenEvents,
   readCodexRateLimitSnapshots,
+  readCopilotOtelEvents,
   readAiderHistoryEvents,
   readGrokUsageEvents,
   readGrokSessionMeta,
@@ -47,6 +48,7 @@ const CLAUDE_FIXTURE = join(FIXTURES, 'claude-transcript.jsonl');
 const CODEX_FIXTURE = join(FIXTURES, 'codex-rollout.jsonl');
 const CLAUDE_EDGE_FIXTURE = join(FIXTURES, 'claude-edge.jsonl');
 const CODEX_EDGE_FIXTURE = join(FIXTURES, 'codex-edge.jsonl');
+const COPILOT_FIXTURE = join(FIXTURES, 'copilot-rollout.jsonl');
 
 const TMP = mkdtempSync(join(tmpdir(), 'tokimeter-parsers-'));
 function tmpFile(name, contents) {
@@ -128,6 +130,60 @@ test('codex rollout: externalIds are unique per line', () => {
   const events = readCodexTokenEvents(CODEX_FIXTURE);
   const ids = events.map(e => e.externalId);
   assert.equal(new Set(ids).size, ids.length);
+});
+
+test('copilot rollout: parses usage spans', () => {
+  const events = readCopilotOtelEvents(COPILOT_FIXTURE);
+
+  assert.equal(events.length, 2);
+
+  const first = events[0];
+
+  assert.equal(first.provider, 'github');
+  assert.equal(first.tool, 'copilot');
+  assert.equal(first.source, 'copilot-otel');
+  assert.equal(first.confidence, 'exact');
+
+  assert.equal(first.model, 'gpt-5.5');
+
+  assert.equal(first.inputTokens, 1200);
+  assert.equal(first.cachedTokens, 300);
+  assert.equal(first.outputTokens, 120);
+  assert.equal(first.reasoningTokens, 40);
+
+  assert.equal(first.sessionId, 'conversation-1');
+});
+
+test('copilot rollout: invoke_agent is shadowed by chat', () => {
+  const events = readCopilotOtelEvents(COPILOT_FIXTURE);
+
+  assert.equal(events.length, 2);
+
+  const ids = events.map(e => e.externalId);
+
+  assert.equal(new Set(ids).size, ids.length);
+});
+
+test('copilot rollout: models and sessions are preserved', () => {
+  const events = readCopilotOtelEvents(COPILOT_FIXTURE);
+
+  assert.equal(events[0].model, 'gpt-5.5');
+  assert.equal(events[1].model, 'gpt-5.4-mini');
+
+  assert.equal(events[0].sessionId, 'conversation-1');
+  assert.equal(events[1].sessionId, 'conversation-2');
+});
+
+test('copilot rollout: respects sinceMs', () => {
+  const events = readCopilotOtelEvents(
+    COPILOT_FIXTURE,
+    {
+      sinceMs: Date.parse('2026-07-08T11:01:00.000Z'),
+    },
+  );
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].model, 'gpt-5.4-mini');
 });
 
 test('claude edge fixture: survives nulls, scalars, missing fields, partial writes', () => {


### PR DESCRIPTION
## Summary

This PR adds a rollout fixture and regression tests for the GitHub Copilot OTEL parser.

The fixture follows the existing testing style used for Claude and Codex by using a small, deterministic synthetic telemetry file rather than a scrubbed real-world trace.

## What is covered

The new tests verify that the parser:

- Parses Copilot usage spans into `UsageEvent`s.
- Preserves provider, tool, source, confidence, model, and session metadata.
- Correctly subtracts `cache_read.input_tokens` from billable input tokens while preserving cached token counts.
- Preserves output and reasoning token counts.
- Suppresses duplicate usage by preferring the `chat` span over the corresponding `invoke_agent` span.
- Respects `sinceMs` filtering.
- Ignores malformed and unrelated telemetry contained in the fixture.

## Notes

While validating the parser against real Copilot telemetry, I noticed that one model is currently missing from the pricing table. Since pricing is handled downstream from the parser, I left that for a separate change to keep this PR focused.