### PR TITLE
Prepare npm 0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ The versioning is [semver](https://semver.org); pre-1.0, minor versions may add 
 
 ## Unreleased
 
+## 0.5.6 — 2026-08-02
+
+### Fixed
+
+- Make generated Tokimeter, `tm`, Codex, and Claude launchers follow the
+  currently active global Tokimeter installation instead of pinning the Node
+  version that was active during setup.
+- Detect legacy Node-version-pinned launchers in `tokimeter doctor` and show an
+  actionable repair message instead of a `MODULE_NOT_FOUND` stack trace when
+  an old Node installation has been removed.
+
+### Pricing
+
+- Add Anthropic's published Claude Opus 5 API price.
+- Recognize `codex-auto-review` as an internal, intentionally unpriced model
+  identifier rather than applying an unsupported public-model price.
+
 ## 0.5.5 — 2026-07-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>
-  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="358" height="40" alt="npm v0.5.5, release v0.5.4, MIT license, Node 18+" align="right" hspace="2"></a>
+  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="358" height="40" alt="npm v0.5.6, release v0.5.4, MIT license, Node 18+" align="right" hspace="2"></a>
   <img src="readme-wordmark.svg" width="190" height="48" alt="Tokimeter">
 </h1>
 

--- a/readme-badges.svg
+++ b/readme-badges.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="358" height="40" viewBox="0 0 358 40" role="img" aria-label="npm v0.5.5, release v0.5.4, MIT license, Node 18+">
-  <title>npm v0.5.5 · release v0.5.4 · MIT · Node 18+</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="358" height="40" viewBox="0 0 358 40" role="img" aria-label="npm v0.5.6, release v0.5.4, MIT license, Node 18+">
+  <title>npm v0.5.6 · release v0.5.4 · MIT · Node 18+</title>
   <defs>
     <clipPath id="npm">
       <rect x="0" y="12" width="82" height="20" rx="3"/>
@@ -34,7 +34,7 @@
 
   <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
     <text x="18" y="26" text-anchor="middle">npm</text>
-    <text x="59" y="26" text-anchor="middle">v0.5.5</text>
+    <text x="59" y="26" text-anchor="middle">v0.5.6</text>
     <text x="116" y="26" text-anchor="middle">release</text>
     <text x="165" y="26" text-anchor="middle">v0.5.4</text>
     <text x="220" y="26" text-anchor="middle">License</text>

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -58,7 +58,7 @@
     },
     "packages/proxy": {
       "name": "tokimeter",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "MIT",
       "bin": {
         "tm": "src/cli.js",

--- a/ts/packages/proxy/package.json
+++ b/ts/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokimeter",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Local-first usage & cost meter for AI coding agents (Claude Code, Codex, Cursor, Grok Build, Hermes, opencode, Cline, Copilot CLI). Inline status-line HUDs, zero-setup reports, 5h-window limits, budgets — no telemetry.",
   "type": "module",
   "main": "src/server.js",


### PR DESCRIPTION
## Release scope

Prepare npm patch `tokimeter@0.5.6` from current public `main`.

Included since `v0.5.5`:

- Node-version-independent generated launchers and legacy-shim diagnostics
- current Claude Opus 5 pricing
- intentional unpriced handling for the internal `codex-auto-review` identifier

OpenHuman PR #28 and held Venice PR #27 are not included.

## Metadata

- bump `ts/packages/proxy/package.json` and workspace lockfile to `0.5.6`
- add the `0.5.6` changelog entry
- update only the npm portion of the static README badge
- leave the GitHub release badge at `v0.5.4`; this action does not create a GitHub release

## Verification

- npm registry latest before release: `0.5.5`
- `node scripts/privacy-check.mjs --ci`
- `node scripts/privacy-check.mjs --precommit`
- `python3 tests/test_basic.py` (30 passed)
- `cd ts && npm test` (111 passed)
- `cd ts && npm run pack:proxy:dry` (11 expected public files)

After merge, the existing stage-only procedure requires an exact `v0.5.6` tag,
manual workflow dispatch, staged package review, and maintainer 2FA approval.
