### PR TITLE
Add one-command Tokimeter installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Runs one private report from the usage metadata already on your machine.
 Reports, budgets, limit warnings, live status-line HUDs, and more:
 
 ```bash
-npm install -g tokimeter && "$(npm prefix -g)/bin/tokimeter" setup --auto
+npx tokimeter install
 ```
 
 <p align="center">
@@ -76,11 +76,17 @@ configuration, or API keys are needed.
 
 ## Setup details
 
-Preview every file and process action first, with no mutation:
+`npx tokimeter install` installs the same Tokimeter version globally, runs the
+reviewable `setup --auto` flow, and verifies the result. It is an explicit CLI
+command, not an automatic npm lifecycle script. Preview it without changing
+anything:
 
 ```bash
-tokimeter setup --auto --dry-run
+npx tokimeter install --dry-run
 ```
+
+For an existing global installation, `tokimeter setup --auto --dry-run` still
+previews only the setup actions.
 
 Close and reopen your terminal when setup finishes. Then keep using `codex`,
 `claude`, and your other supported tools normally; Tokimeter keeps its local

--- a/ts/packages/proxy/README.md
+++ b/ts/packages/proxy/README.md
@@ -27,7 +27,7 @@ Runs one private report from the usage metadata already on your machine.
 Reports, budgets, limit warnings, live status-line HUDs, and more:
 
 ```bash
-npm install -g tokimeter && "$(npm prefix -g)/bin/tokimeter" setup --auto
+npx tokimeter install
 ```
 
 ## Why Tokimeter exists
@@ -75,9 +75,14 @@ account identity or credential is read or stored.
 
 ## Setup details
 
-Run `tokimeter setup --auto --dry-run` to print every planned file/process
-action without changing anything. `tokimeter uninstall` restores prior
-supported-tool settings and removes Tokimeter-generated setup files.
+`npx tokimeter install` installs the same Tokimeter version globally, runs the
+reviewable `setup --auto` flow, and verifies the result. It is an explicit CLI
+command, not an automatic npm lifecycle script. Run
+`npx tokimeter install --dry-run` to preview the install and setup without
+changing anything. For an existing global installation,
+`tokimeter setup --auto --dry-run` previews only the setup actions.
+`tokimeter uninstall` restores prior supported-tool settings and removes
+Tokimeter-generated setup files.
 
 Close and reopen your terminal when setup finishes. Then keep using `codex`,
 `claude`, and your other supported tools normally. Calling the executable by

--- a/ts/packages/proxy/src/cli.js
+++ b/ts/packages/proxy/src/cli.js
@@ -22,7 +22,7 @@
  * Uses Node.js built-ins, with optional node-pty for interactive terminal overlays.
  */
 
-import { execFileSync, spawn } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { appendFileSync, chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
@@ -206,6 +206,10 @@ if (args[0] === 'claude-import') {
   const importOptions = parseClaudeImportArgs(args.slice(1));
   await importClaudeTranscriptUsage({ verbose: !importOptions.quiet, ...importOptions });
   process.exit(0);
+}
+if (args[0] === 'install') {
+  installTokimeter(args.slice(1));
+  process.exit(process.exitCode || 0);
 }
 if (args[0] === 'setup') {
   await setupTool(args.slice(1));
@@ -724,6 +728,95 @@ async function setupTool(setupArgs) {
     console.log(`  Tip: run "tokimeter setup ${target} --auto" to make normal ${allTargets.join('/')} commands route through Tokimeter.`);
   }
   console.log(`  Revert these setup changes with: tokimeter uninstall`);
+}
+
+function installTokimeter(installArgs) {
+  const supportedArgs = new Set(['--dry-run']);
+  const unknown = installArgs.filter(arg => !supportedArgs.has(arg));
+  if (unknown.length > 0) {
+    console.error(`\n  ❌ Unknown install option: ${unknown[0]}`);
+    console.error(`     Use: npx tokimeter install [--dry-run]\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const dryRun = installArgs.includes('--dry-run');
+  const version = readProxyPackageVersion();
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)) {
+    console.error(`\n  ❌ Tokimeter could not determine a valid package version.`);
+    console.error(`     Try again with: npx tokimeter@latest install\n`);
+    process.exitCode = 1;
+    return;
+  }
+  const packageSpec = `tokimeter@${version}`;
+
+  console.log(`\n  Tokimeter Install${dryRun ? ' Dry Run' : ''}`);
+  console.log(`  ──────────────────────────────────────────────`);
+  console.log(`  1. Install stable runtime: npm install --global ${packageSpec}`);
+  console.log(`  2. Configure local meter: tokimeter setup --auto`);
+  console.log(`  3. Verify setup and print any action needed`);
+  console.log(`  ──────────────────────────────────────────────`);
+
+  if (dryRun) {
+    console.log(`  No packages, files, processes, or settings were changed.\n`);
+    return;
+  }
+
+  console.log(`\n  Installing ${packageSpec}...\n`);
+  const npmInstall = spawnSync('npm', ['install', '--global', packageSpec], {
+    stdio: 'inherit',
+    env: process.env,
+    shell: process.platform === 'win32',
+  });
+  if (npmInstall.error || npmInstall.status !== 0) {
+    const detail = npmInstall.error?.message || `npm exited with status ${npmInstall.status}`;
+    console.error(`\n  ❌ Tokimeter could not install the stable runtime: ${detail}`);
+    console.error(`     Fix the npm error above, then run: npx tokimeter install\n`);
+    process.exitCode = npmInstall.status || 1;
+    return;
+  }
+
+  const npmRoot = spawnSync('npm', ['root', '--global'], {
+    encoding: 'utf8',
+    env: process.env,
+    shell: process.platform === 'win32',
+  });
+  if (npmRoot.error || npmRoot.status !== 0) {
+    const detail = npmRoot.error?.message || String(npmRoot.stderr || '').trim() || `npm exited with status ${npmRoot.status}`;
+    console.error(`\n  ❌ Tokimeter was installed, but npm's global package directory could not be resolved: ${detail}`);
+    console.error(`     Run: tokimeter setup --auto\n`);
+    process.exitCode = npmRoot.status || 1;
+    return;
+  }
+
+  const globalRoot = String(npmRoot.stdout || '')
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .at(-1) || '';
+  const installedCli = join(globalRoot, 'tokimeter', 'src', 'cli.js');
+  if (!globalRoot || !existsSync(installedCli)) {
+    console.error(`\n  ❌ Tokimeter was installed, but its CLI was not found in npm's global package directory.`);
+    console.error(`     Run: tokimeter setup --auto\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`\n  Configuring the local meter...\n`);
+  const setup = spawnSync(process.execPath, [installedCli, 'setup', '--auto'], {
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (setup.error || setup.status !== 0) {
+    const detail = setup.error?.message || `setup exited with status ${setup.status}`;
+    console.error(`\n  ❌ Tokimeter installed, but setup did not finish: ${detail}`);
+    console.error(`     Retry with: tokimeter setup --auto\n`);
+    process.exitCode = setup.status || 1;
+    return;
+  }
+
+  console.log(`\n  ✓ Tokimeter is installed. Restart the terminal if setup added Tokimeter to PATH.`);
+  console.log(`    Check anytime with: tokimeter doctor\n`);
 }
 
 function buildSetupPlan({ target, auto, claudeSpinner }) {
@@ -6234,7 +6327,9 @@ function printHelp() {
     tokimeter sync [--days=30]   Sync all supported tools now (metadata only)
     tokimeter login <url> <key>  Advanced: connect with an ingest URL + device key
     tokimeter logout             Disable sync and remove the stored device key
-    tokimeter setup --auto       One-command local install for Codex + Claude
+    tokimeter install            Install stable runtime + configure local meter
+    tokimeter install --dry-run  Show install/setup actions; change nothing
+    tokimeter setup --auto       Configure local meter for Codex + Claude
     tokimeter setup [tool]       Configure a specific local tool profile
     tokimeter setup --dry-run    Print exact setup files/actions; change nothing
     tokimeter setup cursor       Cursor CLI: Tokimeter status line + exact per-turn usage capture (hook)
@@ -6252,6 +6347,7 @@ function printHelp() {
     tokimeter aider [args]         Aider (OpenAI-provider models)
 
   Examples:
+    npx tokimeter install
     tokimeter claude "refactor auth.py"
     tokimeter codex "fix the bug in utils.js"
     tm codex-chatgpt exec --skip-git-repo-check "say hello"

--- a/ts/test/setup.test.js
+++ b/ts/test/setup.test.js
@@ -1,9 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { delimiter, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -43,6 +43,50 @@ function tree(root) {
   return result.sort();
 }
 
+function fakeNpmEnv(root, { installStatus = 0, includeInstalledCli = true } = {}) {
+  const binDir = join(root, 'fake-bin');
+  const globalRoot = join(root, 'fake-global', 'lib', 'node_modules');
+  const logFile = join(root, 'install-commands.jsonl');
+  const npmPath = join(binDir, process.platform === 'win32' ? 'npm.cmd' : 'npm');
+  const fakeNpmScript = join(binDir, 'fake-npm.mjs');
+  const installedCli = join(globalRoot, 'tokimeter', 'src', 'cli.js');
+  mkdirSync(binDir, { recursive: true });
+
+  if (includeInstalledCli) {
+    mkdirSync(dirname(installedCli), { recursive: true });
+    writeFileSync(installedCli, `#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+appendFileSync(${JSON.stringify(logFile)}, JSON.stringify({ command: 'installed-cli', args: process.argv.slice(2) }) + '\\n');
+`);
+  }
+
+  const fakeNpm = `#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+const args = process.argv.slice(2);
+appendFileSync(${JSON.stringify(logFile)}, JSON.stringify({ command: 'npm', args }) + '\\n');
+if (args[0] === 'install') process.exit(${installStatus});
+if (args[0] === 'root' && args[1] === '--global') {
+  console.log(${JSON.stringify(globalRoot)});
+  process.exit(0);
+}
+process.exit(2);
+`;
+  writeFileSync(fakeNpmScript, fakeNpm, { mode: 0o755 });
+  if (process.platform === 'win32') {
+    writeFileSync(npmPath, `@"${process.execPath}" "${fakeNpmScript}" %*\r\n`);
+  } else {
+    writeFileSync(npmPath, fakeNpm, { mode: 0o755 });
+  }
+
+  return {
+    env: {
+      ...isolatedEnv(root),
+      PATH: `${binDir}${delimiter}${process.env.PATH || ''}`,
+    },
+    logFile,
+  };
+}
+
 test('setup --dry-run prints exact plan and performs no mutation', (t) => {
   const root = mkdtempSync(join(tmpdir(), 'tokimeter-setup-dry-'));
   t.after(() => rmSync(root, { recursive: true, force: true }));
@@ -59,6 +103,60 @@ test('setup --dry-run prints exact plan and performs no mutation', (t) => {
   assert.match(output, /No files, processes, or settings were changed/);
   assert.match(output, /tokimeter uninstall/);
   assert.deepEqual(tree(root), before);
+});
+
+test('install pins the running package version and delegates to stable global setup', (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'tokimeter-install-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const { env, logFile } = fakeNpmEnv(root);
+  const pkg = JSON.parse(readFileSync(PACKAGE_JSON, 'utf8'));
+
+  const output = execFileSync(process.execPath, [CLI, 'install'], {
+    encoding: 'utf8',
+    env,
+  });
+  const commands = readFileSync(logFile, 'utf8').trim().split(/\r?\n/).map(line => JSON.parse(line));
+
+  assert.match(output, /Tokimeter Install/);
+  assert.match(output, /Tokimeter is installed/);
+  assert.deepEqual(commands, [
+    { command: 'npm', args: ['install', '--global', `tokimeter@${pkg.version}`] },
+    { command: 'npm', args: ['root', '--global'] },
+    { command: 'installed-cli', args: ['setup', '--auto'] },
+  ]);
+});
+
+test('install dry-run performs no package or setup command', (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'tokimeter-install-dry-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const { env, logFile } = fakeNpmEnv(root, { includeInstalledCli: false });
+
+  const output = execFileSync(process.execPath, [CLI, 'install', '--dry-run'], {
+    encoding: 'utf8',
+    env,
+  });
+
+  assert.match(output, /Tokimeter Install Dry Run/);
+  assert.match(output, /No packages, files, processes, or settings were changed/);
+  assert.equal(existsSync(logFile), false);
+});
+
+test('install stops before setup when npm global install fails', (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'tokimeter-install-fail-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const { env, logFile } = fakeNpmEnv(root, { installStatus: 42, includeInstalledCli: false });
+
+  const result = spawnSync(process.execPath, [CLI, 'install'], {
+    encoding: 'utf8',
+    env,
+  });
+  const commands = readFileSync(logFile, 'utf8').trim().split(/\r?\n/).map(line => JSON.parse(line));
+
+  assert.equal(result.status, 42);
+  assert.match(result.stderr, /could not install the stable runtime/);
+  assert.deepEqual(commands, [
+    { command: 'npm', args: ['install', '--global', `tokimeter@${JSON.parse(readFileSync(PACKAGE_JSON, 'utf8')).version}`] },
+  ]);
 });
 
 test('setup plan is shown before mutation and uninstall restores prior configs', (t) => {


### PR DESCRIPTION
## Summary
- add an explicit one-command installer: npx tokimeter install
- install the matching package version globally before running the stable setup flow
- add dry-run, failure handling, package documentation, and focused tests

## Verification
- node scripts/privacy-check.mjs --ci
- python3 tests/test_basic.py
- cd ts and npm test
- packed npm artifact installer dry-run