### PR TITLE
Prepare npm 0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The versioning is [semver](https://semver.org); pre-1.0, minor versions may add 
 
 ## Unreleased
 
+## 0.5.7 — 2026-08-02
+
+### Added
+
+- Add `npx tokimeter install` as the single public command for installing the
+  stable global runtime, configuring supported local integrations, and
+  verifying setup.
+- Add `npx tokimeter install --dry-run` to preview the package and setup actions
+  without changing packages, files, processes, or settings.
+- Pin installation to the same package version already running through `npx`,
+  then invoke setup from npm's resolved global package directory instead of
+  relying on a newly refreshed shell `PATH`.
+
+### Safety
+
+- Keep installation explicit; the npm package still has no `install` or
+  `postinstall` lifecycle hook.
+- Stop before setup when the global package installation fails and provide a
+  direct recovery command when global resolution or setup cannot finish.
+
 ## 0.5.6 — 2026-08-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>
-  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="358" height="40" alt="npm v0.5.6, release v0.5.4, MIT license, Node 18+" align="right" hspace="2"></a>
+  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="358" height="40" alt="npm v0.5.7, release v0.5.4, MIT license, Node 18+" align="right" hspace="2"></a>
   <img src="readme-wordmark.svg" width="190" height="48" alt="Tokimeter">
 </h1>
 

--- a/readme-badges.svg
+++ b/readme-badges.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="358" height="40" viewBox="0 0 358 40" role="img" aria-label="npm v0.5.6, release v0.5.4, MIT license, Node 18+">
-  <title>npm v0.5.6 · release v0.5.4 · MIT · Node 18+</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="358" height="40" viewBox="0 0 358 40" role="img" aria-label="npm v0.5.7, release v0.5.4, MIT license, Node 18+">
+  <title>npm v0.5.7 · release v0.5.4 · MIT · Node 18+</title>
   <defs>
     <clipPath id="npm">
       <rect x="0" y="12" width="82" height="20" rx="3"/>
@@ -34,7 +34,7 @@
 
   <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
     <text x="18" y="26" text-anchor="middle">npm</text>
-    <text x="59" y="26" text-anchor="middle">v0.5.6</text>
+    <text x="59" y="26" text-anchor="middle">v0.5.7</text>
     <text x="116" y="26" text-anchor="middle">release</text>
     <text x="165" y="26" text-anchor="middle">v0.5.4</text>
     <text x="220" y="26" text-anchor="middle">License</text>

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -58,7 +58,7 @@
     },
     "packages/proxy": {
       "name": "tokimeter",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "MIT",
       "bin": {
         "tm": "src/cli.js",

--- a/ts/packages/proxy/package.json
+++ b/ts/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokimeter",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Local-first usage & cost meter for AI coding agents (Claude Code, Codex, Cursor, Grok Build, Hermes, opencode, Cline, Copilot CLI). Inline status-line HUDs, zero-setup reports, 5h-window limits, budgets — no telemetry.",
   "type": "module",
   "main": "src/server.js",


### PR DESCRIPTION
## Summary
- bump the Tokimeter npm package to 0.5.7
- document the new `npx tokimeter install` flow
- update the npm version badge

## Verification
- `node scripts/privacy-check.mjs --ci`
- `python3 tests/test_basic.py` (30 passed)
- `cd ts && npm test` (114 passed)
- `cd ts && npm run pack:proxy:dry` (11 expected files)