### PR TITLE
Unify installer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,7 @@ may still need its own global Tokimeter install. If a launcher created by an
 older Tokimeter release fails with `MODULE_NOT_FOUND`, repair it once with:
 
 ```bash
-npm install -g tokimeter
-"$(npm prefix -g)/bin/tokimeter" setup --auto
-hash -r
+npx tokimeter install
 ```
 
 ## Am I about to hit my limit?

--- a/ts/packages/proxy/README.md
+++ b/ts/packages/proxy/README.md
@@ -96,9 +96,7 @@ Node version. To migrate a launcher written by an older release after a
 `MODULE_NOT_FOUND` error:
 
 ```bash
-npm install -g tokimeter
-"$(npm prefix -g)/bin/tokimeter" setup --auto
-hash -r
+npx tokimeter install
 ```
 
 ## Limits: the 5-hour window


### PR DESCRIPTION
## Summary
- replace the last legacy multi-command repair block with `npx tokimeter install`
- keep the public and npm-facing READMEs aligned

## Verification
- `node scripts/privacy-check.mjs --ci`
- `node scripts/privacy-check.mjs --precommit`