### PR TITLE
Prepare npm 0.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The versioning is [semver](https://semver.org); pre-1.0, minor versions may add 
 
 ## Unreleased
 
+## 0.5.8 — 2026-08-03
+
+### Fixed
+
+- Classify Codex vendor-reported rate-limit windows by their recorded duration
+  instead of assuming the primary slot is five hours and the secondary slot is
+  weekly.
+- Label a weekly-only primary window correctly, order reversed five-hour and
+  weekly slots consistently, and display unfamiliar durations literally
+  without inventing quota semantics.
+- Preserve the same duration classification when syncing supported Codex limit
+  snapshots to the optional hosted dashboard.
+
 ## 0.5.7 — 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>
-  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="358" height="40" alt="npm v0.5.7, release v0.5.4, MIT license, Node 18+" align="right" hspace="2"></a>
+  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="358" height="40" alt="npm v0.5.8, release v0.5.4, MIT license, Node 18+" align="right" hspace="2"></a>
   <img src="readme-wordmark.svg" width="190" height="48" alt="Tokimeter">
 </h1>
 

--- a/readme-badges.svg
+++ b/readme-badges.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="358" height="40" viewBox="0 0 358 40" role="img" aria-label="npm v0.5.7, release v0.5.4, MIT license, Node 18+">
-  <title>npm v0.5.7 · release v0.5.4 · MIT · Node 18+</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="358" height="40" viewBox="0 0 358 40" role="img" aria-label="npm v0.5.8, release v0.5.4, MIT license, Node 18+">
+  <title>npm v0.5.8 · release v0.5.4 · MIT · Node 18+</title>
   <defs>
     <clipPath id="npm">
       <rect x="0" y="12" width="82" height="20" rx="3"/>
@@ -34,7 +34,7 @@
 
   <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
     <text x="18" y="26" text-anchor="middle">npm</text>
-    <text x="59" y="26" text-anchor="middle">v0.5.7</text>
+    <text x="59" y="26" text-anchor="middle">v0.5.8</text>
     <text x="116" y="26" text-anchor="middle">release</text>
     <text x="165" y="26" text-anchor="middle">v0.5.4</text>
     <text x="220" y="26" text-anchor="middle">License</text>

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -58,7 +58,7 @@
     },
     "packages/proxy": {
       "name": "tokimeter",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "MIT",
       "bin": {
         "tm": "src/cli.js",

--- a/ts/packages/proxy/package.json
+++ b/ts/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokimeter",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Local-first usage & cost meter for AI coding agents (Claude Code, Codex, Cursor, Grok Build, Hermes, opencode, Cline, Copilot CLI). Inline status-line HUDs, zero-setup reports, 5h-window limits, budgets — no telemetry.",
   "type": "module",
   "main": "src/server.js",


### PR DESCRIPTION
## Summary
- bump the Tokimeter npm package to 0.5.8
- document the Codex rate-limit duration classification fix
- update the npm version badge

## Verification
- `node scripts/privacy-check.mjs --ci`
- `python3 tests/test_basic.py` (30 passed)
- `cd ts && npm test` (117 passed)
- `cd ts && npm run pack:proxy:dry` (11 expected files)