### PR TITLE
Fix npm 0.5.8 changelog date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The versioning is [semver](https://semver.org); pre-1.0, minor versions may add 
 
 ## Unreleased
 
-## 0.5.8 — 2026-08-03
+## 0.5.8 — 2026-08-02
 
 ### Fixed
 


### PR DESCRIPTION
The changelog declares UTC dates. Correct the 0.5.8 heading from the Seoul-local August 3 date to the actual UTC release date, August 2, before creating the immutable tag.

Verification: `node scripts/privacy-check.mjs --precommit`.