### PR TITLE
docs: refer to the private repository by role, not name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ reachable Git commit as public.
 - Never add the private website or dashboard source, Supabase server functions
   or service credentials, billing implementation, Cloudflare configuration,
   contact-form recipient addresses, private launch plans, or operational
-  handoffs. Those belong only in the private `tokimeter-cloud` repository or in
+  handoffs. Those belong only in the private hosted-product repository or in
   ignored local working directories.
 - Never commit secrets, access tokens, environment files, private keys,
   credentials, personal email addresses, real customer data, prompt or response
@@ -47,8 +47,8 @@ reachable Git commit as public.
   archive/delete repositories, or deploy the hosted website without explicit
   user approval.
 - Never deploy directly to Cloudflare from this public repository. The website
-  is deployed from the private `tokimeter-cloud` repository through its
-  existing integration.
+  is deployed from the private hosted-product repository through its existing
+  integration.
 
 ## Required verification
 


### PR DESCRIPTION
The repository-boundary rules in `AGENTS.md` named the private hosted-product repository directly. The rule does not depend on the name, so this describes it by role instead.

The exact name stays in `.codex/NEXT_SESSION_HANDOFF.md`, which is ignored and is where agents that need it already look.

## No policy change

Still banned from this repository: private website and dashboard source, Supabase server functions and service credentials, billing implementation, Cloudflare configuration, contact-form recipient addresses, private launch plans, and operational handoffs. The website still deploys only from the private repository, never from here.

## Scope

Two lines in one file. No code, no tests, no package contents.

Note that this only affects the current tree — the name remains in reachable history from #7 (2026-07-28). Removing it there would require rewriting public history, which `AGENTS.md` forbids without a separate explicit decision.