### PR TITLE
Prepare npm 0.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The versioning is [semver](https://semver.org); pre-1.0, minor versions may add 
 
 ## Unreleased
 
+## 0.5.10 — 2026-08-03
+
 ### Fixed
 
 - Keep `setup --auto` from failing when the shell configuration file cannot be

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>
-  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="358" height="40" alt="npm v0.5.9, release v0.5.4, MIT license, Node 18+" align="right" hspace="2"></a>
+  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="374" height="40" alt="npm v0.5.10, release v0.5.10, MIT license, Node 18+" align="right" hspace="2"></a>
   <img src="readme-wordmark.svg" width="190" height="48" alt="Tokimeter">
 </h1>
 

--- a/readme-badges.svg
+++ b/readme-badges.svg
@@ -1,45 +1,45 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="358" height="40" viewBox="0 0 358 40" role="img" aria-label="npm v0.5.9, release v0.5.4, MIT license, Node 18+">
-  <title>npm v0.5.9 · release v0.5.4 · MIT · Node 18+</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="374" height="40" viewBox="0 0 374 40" role="img" aria-label="npm v0.5.10, release v0.5.10, MIT license, Node 18+">
+  <title>npm v0.5.10 · release v0.5.10 · MIT · Node 18+</title>
   <defs>
     <clipPath id="npm">
-      <rect x="0" y="12" width="82" height="20" rx="3"/>
+      <rect x="0" y="12" width="90" height="20" rx="3"/>
     </clipPath>
     <clipPath id="release">
-      <rect x="90" y="12" width="98" height="20" rx="3"/>
+      <rect x="98" y="12" width="106" height="20" rx="3"/>
     </clipPath>
     <clipPath id="license">
-      <rect x="196" y="12" width="82" height="20" rx="3"/>
+      <rect x="212" y="12" width="82" height="20" rx="3"/>
     </clipPath>
     <clipPath id="node">
-      <rect x="286" y="12" width="72" height="20" rx="3"/>
+      <rect x="302" y="12" width="72" height="20" rx="3"/>
     </clipPath>
   </defs>
 
   <g clip-path="url(#npm)">
     <rect x="0" y="12" width="36" height="20" fill="#555"/>
-    <rect x="36" y="12" width="46" height="20" fill="#e76f51"/>
+    <rect x="36" y="12" width="54" height="20" fill="#e76f51"/>
   </g>
   <g clip-path="url(#release)">
-    <rect x="90" y="12" width="52" height="20" fill="#555"/>
-    <rect x="142" y="12" width="46" height="20" fill="#e76f51"/>
+    <rect x="98" y="12" width="52" height="20" fill="#555"/>
+    <rect x="150" y="12" width="54" height="20" fill="#e76f51"/>
   </g>
   <g clip-path="url(#license)">
-    <rect x="196" y="12" width="48" height="20" fill="#555"/>
-    <rect x="244" y="12" width="34" height="20" fill="#d4aa00"/>
+    <rect x="212" y="12" width="48" height="20" fill="#555"/>
+    <rect x="260" y="12" width="34" height="20" fill="#d4aa00"/>
   </g>
   <g clip-path="url(#node)">
-    <rect x="286" y="12" width="38" height="20" fill="#555"/>
-    <rect x="324" y="12" width="34" height="20" fill="#4c9a22"/>
+    <rect x="302" y="12" width="38" height="20" fill="#555"/>
+    <rect x="340" y="12" width="34" height="20" fill="#4c9a22"/>
   </g>
 
   <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
     <text x="18" y="26" text-anchor="middle">npm</text>
-    <text x="59" y="26" text-anchor="middle">v0.5.9</text>
-    <text x="116" y="26" text-anchor="middle">release</text>
-    <text x="165" y="26" text-anchor="middle">v0.5.4</text>
-    <text x="220" y="26" text-anchor="middle">License</text>
-    <text x="261" y="26" text-anchor="middle">MIT</text>
-    <text x="305" y="26" text-anchor="middle">node</text>
-    <text x="341" y="26" text-anchor="middle">18+</text>
+    <text x="63" y="26" text-anchor="middle">v0.5.10</text>
+    <text x="124" y="26" text-anchor="middle">release</text>
+    <text x="177" y="26" text-anchor="middle">v0.5.10</text>
+    <text x="236" y="26" text-anchor="middle">License</text>
+    <text x="277" y="26" text-anchor="middle">MIT</text>
+    <text x="321" y="26" text-anchor="middle">node</text>
+    <text x="357" y="26" text-anchor="middle">18+</text>
   </g>
 </svg>

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -58,7 +58,7 @@
     },
     "packages/proxy": {
       "name": "tokimeter",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "license": "MIT",
       "bin": {
         "tm": "src/cli.js",

--- a/ts/packages/proxy/package.json
+++ b/ts/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokimeter",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Local-first usage & cost meter for AI coding agents (Claude Code, Codex, Cursor, Grok Build, Hermes, opencode, Cline, Copilot CLI). Inline status-line HUDs, zero-setup reports, 5h-window limits, budgets — no telemetry.",
   "type": "module",
   "main": "src/server.js",


### PR DESCRIPTION
Release preparation for `0.5.10`, which ships the best-effort shell PATH fix from #37. Setup no longer fails when the shell configuration file cannot be written, unblocking NixOS and Home Manager installs.

## Changes

- Bump `ts/packages/proxy/package.json` and `ts/package-lock.json` to `0.5.10`.
- Date the changelog entry `0.5.10 — 2026-08-03` and leave `Unreleased` empty.
- Refresh the README badge to `npm v0.5.10` / `release v0.5.10`.

The badge value pills widen by 8px each (46 → 54) to fit the two-digit patch version, shifting the license and node groups right and taking the SVG from 358px to 374px. Rendered and checked: no clipping, padding stays even. The release badge also catches up, having read `v0.5.4` while the latest release was `v0.5.6`.

## Verification

```
node scripts/privacy-check.mjs --ci   # passed, 11 tarball files
python3 tests/test_basic.py           # 30 passed, 0 failed
cd ts && npm test                     # 119 passed, 0 failed
```

## Not included

No tag, GitHub release, or npm publish happens here. Those are separate approved actions after this merges.

Per the release decision, GitHub releases are not being backfilled for `0.5.7`–`0.5.9`; `v0.5.10` will be the next release published.