### PR TITLE
Scope the Git identity rule to maintainer commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,15 @@ Keep both test suites green. CI runs them on every push.
 Run `npm run privacy:check` from `ts/` before opening a pull request. The same
 gate runs in CI, before local commits and pushes after `privacy:setup`, and
 before npm publishing. It rejects unapproved email addresses, user-directory
-paths, common secrets, private workspace files, unexpected npm tarball files,
-and non-brand Git author identities. Use reserved `example.com`, `example.net`,
-or `example.org` addresses in fixtures and documentation.
+paths, common secrets, private workspace files, and unexpected npm tarball
+files. Use reserved `example.com`, `example.net`, or `example.org` addresses in
+fixtures and documentation.
+
+Your commit email is your own choice. The Git identity rule applies only to
+commits authored under the maintainer's name, so you do not need to change your
+public commit address to contribute. If you would rather keep your address
+private, GitHub's `@users.noreply.github.com` option works and needs nothing
+from us.
 
 ## Style
 

--- a/scripts/privacy-check.mjs
+++ b/scripts/privacy-check.mjs
@@ -244,14 +244,29 @@ function checkGitHistory() {
   notes.push(`${scanned} reachable Git history objects scanned`);
 }
 
+// The identity rule exists to keep the maintainer's own address out of public
+// history. An outside contributor's commit email is their own choice, made on
+// their own account, so it is not this gate's business. Commits authored under
+// the maintainer's name stay strictly enforced, because that is the case that
+// would otherwise leak a personal address.
+function isMaintainerAuthored(name) {
+  const normalized = name.trim().toLowerCase();
+  return normalized === EXPECTED_NPM_USER.toLowerCase()
+    || normalized === EXPECTED_AUTHOR.name.toLowerCase();
+}
+
 function checkGitIdentity() {
-  const commitEmails = git(['log', '--all', '--format=%ae'])
+  const commits = git(['log', '--all', '--format=%an%x00%ae'])
     .split('\n')
-    .map((email) => email.trim())
-    .filter(Boolean);
-  const rejected = [...new Set(commitEmails.filter((email) => !isAllowedGitEmail(email)))];
+    .map((line) => line.split('\0'))
+    .filter((parts) => parts.length === 2 && parts[1].trim())
+    .map(([name, email]) => ({ name, email: email.trim() }));
+  const commitEmails = commits.map((commit) => commit.email);
+  const rejected = [...new Set(commits
+    .filter((commit) => isMaintainerAuthored(commit.name) && !isAllowedGitEmail(commit.email))
+    .map((commit) => commit.email))];
   if (rejected.length) {
-    failures.push(`${rejected.length} reachable Git commit email(s) are not GitHub noreply or the approved brand address`);
+    failures.push(`${rejected.length} reachable maintainer commit email(s) are not GitHub noreply or the approved brand address`);
   }
 
   const trustedPublisher = mode === '--prepublish' && process.env.ACTIONS_ID_TOKEN_REQUEST_URL;


### PR DESCRIPTION
The reachable-history identity check in `scripts/privacy-check.mjs` rejected every commit email that was not a GitHub noreply address or the project address. That rule exists to keep the maintainer's own address out of public history, but as written it also blocks outside contributors who commit under their own public email, which is their choice to make on their own account.

This scopes the check to commits authored under the maintainer's name.

## Why not an allowlist

Adding a contributor's address to the allowlist would commit a personal email to a tracked file, which `AGENTS.md` forbids outright. Scoping the rule keeps the gate's intent without storing anyone's address.

## Unchanged

- The file-content email scan still rejects unapproved addresses anywhere in tracked files or reachable history objects.
- The local `git config user.email` check still runs outside CI, so a maintainer machine misconfigured with a personal address still fails.
- Secret scanning, private-path bans, home-directory path detection, and the npm tarball allowlist are untouched.

## Verification

Both directions were tested against real history:

- With PR #26's contributor commit cherry-picked in, the gate passes.
- With a simulated commit authored as `ToshiPepe` using a personal address, the gate still fails with `1 reachable maintainer commit email(s) are not GitHub noreply or the approved brand address`.

```
node scripts/privacy-check.mjs --self-test   # passed
node scripts/privacy-check.mjs --ci          # passed
python3 tests/test_basic.py                  # 30 passed, 0 failed
```

Unblocks #26.