### PR TITLE
Correct the disputed provider rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The versioning is [semver](https://semver.org); pre-1.0, minor versions may add 
 
 ## Unreleased
 
+### Pricing
+
+- Correct Google, Mistral, and DeepSeek rates against each provider's published
+  pricing, verified 2026-08-04. Several were substantially wrong: Gemini 2.5
+  Flash was priced at `$0.075/$0.30` against a published `$0.30/$2.50`, and
+  Gemini 3 Flash at `$0.15/$0.60` against `$1.50/$9.00`.
+- Price Mistral's floating `-latest` aliases against the generation they
+  actually resolve to, and record Mistral's published cache-read discount
+  instead of treating cache reads as unpriced.
+- Replace the delisted DeepSeek models with the currently published ones.
+- Stop shipping a built-in price for Meta Llama models. Meta publishes no
+  generally available first-party API pricing, so Llama usage is now treated as
+  an unknown model and excluded from priced totals rather than valued at a rate
+  that cannot be sourced. Set a custom price for the host you actually use.
+- Drop downgrade suggestions that pointed at models which are no longer priced,
+  so a savings figure can never be computed against an unpriced target.
+- Publish every rate with its source and verification date in `docs/PRICES.md`,
+  generated from the same table the CLI prices with, and fail CI when a
+  provider's verification goes stale or a dated rate change comes due.
+
 ## 0.5.10 — 2026-08-03
 
 ### Fixed

--- a/docs/PRICES.md
+++ b/docs/PRICES.md
@@ -9,10 +9,8 @@ them to locally recorded token counts to produce an API-equivalent value, which
 it marks `~$` precisely because it is not a bill. See
 [the pricing methodology](PRICING.md) for how that distinction is enforced.
 
-66 models across 9 providers.
-5 providers are sourced and verified.
-
-> **4 providers below carry disputed rates.** Google, Mistral, Meta, DeepSeek were checked against their published pricing and did not match. Their sections say so, and their numbers should not be relied on until they are corrected. They are listed here rather than quietly omitted because hiding them would be the dishonest option.
+62 models across 8 priced providers.
+8 of 8 are sourced and verified.
 
 ## OpenAI
 
@@ -62,6 +60,40 @@ GPT-5.6 Sol/Terra/Luna tiers verified 2026-07-11 at short-context standard rates
 | `claude-3-opus` | $15.00 | _not published_ | $18.75 (1.25× input) | $75.00 |
 | `claude-3-haiku` | $0.25 | _not published_ | $0.3125 (1.25× input) | $1.25 |
 
+## Google
+
+**Source:** [ai.google.dev Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing)  
+**Verified:** 2026-08-04
+
+Short-context (<=200k) text tier. Gemini prices audio input and >200k context higher; those tiers are not modeled, so such usage is under-valued rather than guessed.
+
+| Model | Input | Cache read | Cache write | Output |
+|---|---|---|---|---|
+| `gemini-3.6-flash` | $1.50 | $0.15 | $1.875 (1.25× input) | $7.50 |
+| `gemini-3.5-flash` | $1.50 | $0.15 | $1.875 (1.25× input) | $9.00 |
+| `gemini-3.5-flash-lite` | $0.30 | $0.03 | $0.375 (1.25× input) | $2.50 |
+| `gemini-3.1-flash-lite` | $0.25 | $0.025 | $0.3125 (1.25× input) | $1.50 |
+| `gemini-3.1-pro-preview` | $2.00 | $0.20 | $2.50 (1.25× input) | $12.00 |
+| `gemini-2.5-pro` | $1.25 | $0.125 | $1.5625 (1.25× input) | $10.00 |
+| `gemini-2.5-flash` | $0.30 | $0.03 | $0.375 (1.25× input) | $2.50 |
+| `gemini-2.5-flash-lite` | $0.10 | $0.01 | $0.125 (1.25× input) | $0.40 |
+
+## Mistral
+
+**Source:** [mistral.ai/pricing/api](https://mistral.ai/pricing/api/)  
+**Verified:** 2026-08-04
+
+The floating -latest aliases are priced against the current generation they resolve to. Cache read is Mistral's published 90 percent discount.
+
+| Model | Input | Cache read | Cache write | Output |
+|---|---|---|---|---|
+| `mistral-large-3` | $0.50 | $0.05 | $0.625 (1.25× input) | $1.50 |
+| `mistral-medium-3.5` | $1.50 | $0.15 | $1.875 (1.25× input) | $7.50 |
+| `mistral-small-4` | $0.15 | $0.015 | $0.1875 (1.25× input) | $0.60 |
+| `ministral-3-3b` | $0.10 | $0.01 | $0.125 (1.25× input) | $0.10 |
+| `ministral-3-8b` | $0.15 | $0.015 | $0.1875 (1.25× input) | $0.15 |
+| `ministral-3-14b` | $0.20 | $0.02 | $0.25 (1.25× input) | $0.20 |
+
 ## xAI
 
 **Source:** [docs.x.ai Chat and Code API pricing](https://docs.x.ai)  
@@ -80,6 +112,18 @@ grok-4.5 flagship rates verified 2026-07-11.
 | `grok-3` | $3.00 | _not published_ | $3.75 (1.25× input) | $15.00 |
 | `grok-3-mini` | $0.30 | _not published_ | $0.375 (1.25× input) | $0.50 |
 | `grok-2` | $2.00 | _not published_ | $2.50 (1.25× input) | $10.00 |
+
+## DeepSeek
+
+**Source:** [api-docs.deepseek.com pricing](https://api-docs.deepseek.com/quick_start/pricing)  
+**Verified:** 2026-08-04
+
+Standard rates. Announced peak-hour pricing at 2x has no published effective date and is not modeled, so peak usage is under-valued rather than guessed.
+
+| Model | Input | Cache read | Cache write | Output |
+|---|---|---|---|---|
+| `deepseek-v4-flash` | $0.14 | $0.0028 | $0.175 (1.25× input) | $0.28 |
+| `deepseek-v4-pro` | $0.435 | $0.0036 | $0.5437 (1.25× input) | $0.87 |
 
 ## Cursor
 
@@ -106,81 +150,14 @@ Composer 2.5 standard tier. The fast tier is priced under xAI.
 | `glm-4-plus` | $0.50 | _not published_ | $0.625 (1.25× input) | $1.50 |
 | `glm-4-flash` | $0.01 | _not published_ | $0.0125 (1.25× input) | $0.01 |
 
-## Google
+## Intentionally unpriced
 
-**Source:** _not recorded_  
-**Verified:** _not recorded_
+Tokimeter ships no rate for these. Their usage is treated as an unknown model:
+excluded from priced totals rather than valued at a number that cannot be sourced.
 
-> **These rates are disputed.** Checked 2026-08-04 against [published pricing](https://ai.google.dev/gemini-api/docs/pricing).
->
-> Built-in rates disagree with currently published pricing. gemini-2.5-flash is listed at $0.075 / $0.30 against a published $0.30 / $2.50, and gemini-3-flash at $0.15 / $0.60 against a published $1.50 / $9.00. gemini-2.5-pro input and output match the published short-context tier, but its cache-read rate does not. gemini-1.5-pro and gemini-1.5-flash no longer appear on the pricing page. Gemini also tiers rates above 200k context, which the built-in table does not model.
->
-> Treat the rates below as unreliable until they are corrected.
+### Meta
 
-| Model | Input | Cache read | Cache write | Output |
-|---|---|---|---|---|
-| `gemini-2.5-pro` | $1.25 | $0.3125 | $1.5625 (1.25× input) | $10.00 |
-| `gemini-2.5-flash` | $0.075 | $0.0187 | $0.0938 (1.25× input) | $0.30 |
-| `gemini-3-pro` | $2.50 | $0.625 | $3.125 (1.25× input) | $15.00 |
-| `gemini-3-flash` | $0.15 | $0.0375 | $0.1875 (1.25× input) | $0.60 |
-| `gemini-3-flash-lite` | $0.075 | $0.0187 | $0.0938 (1.25× input) | $0.30 |
-| `gemini-1.5-pro` | $1.25 | $0.3125 | $1.5625 (1.25× input) | $5.00 |
-| `gemini-1.5-flash` | $0.075 | $0.0187 | $0.0938 (1.25× input) | $0.30 |
-
-## Mistral
-
-**Source:** _not recorded_  
-**Verified:** _not recorded_
-
-> **These rates are disputed.** Checked 2026-08-04 against [published pricing](https://mistral.ai/pricing/api/).
->
-> The built-in table prices the floating `-latest` aliases at rates from an older model generation. Published pricing lists Mistral Large 3 at $0.50 / $1.50 against a built-in $2.00 / $6.00, and Mistral Medium 3.5 at $1.50 / $7.50 against a built-in $0.40 / $4.00. Mistral now publishes a cache-read rate at a 90 percent discount, which the built-in table records as 0. `codestral` no longer appears on the pricing page.
->
-> Treat the rates below as unreliable until they are corrected.
-
-| Model | Input | Cache read | Cache write | Output |
-|---|---|---|---|---|
-| `mistral-large-latest` | $2.00 | _not published_ | $2.50 (1.25× input) | $6.00 |
-| `mistral-medium-latest` | $0.40 | _not published_ | $0.50 (1.25× input) | $4.00 |
-| `mistral-small-latest` | $0.20 | _not published_ | $0.25 (1.25× input) | $0.60 |
-| `codestral` | $0.30 | _not published_ | $0.375 (1.25× input) | $0.90 |
-
-## Meta
-
-**Source:** _not recorded_  
-**Verified:** _not recorded_
-
-> **These rates are disputed.** Checked 2026-08-04 against published pricing.
->
-> Meta publishes no generally available first-party API pricing; its direct Llama API remains waitlisted. Llama rates come from third-party hosts such as DeepInfra, Groq, and Together, differ between them, and move over time, so no single authoritative rate exists to cite. The built-in numbers cannot be sourced as published Meta pricing.
->
-> Treat the rates below as unreliable until they are corrected.
-
-| Model | Input | Cache read | Cache write | Output |
-|---|---|---|---|---|
-| `llama-4-scout` | $0.20 | _not published_ | $0.25 (1.25× input) | $0.60 |
-| `llama-4-maverick` | $0.27 | _not published_ | $0.3375 (1.25× input) | $0.85 |
-| `llama-3.3-70b` | $0.59 | _not published_ | $0.7375 (1.25× input) | $0.79 |
-| `llama-3.1-405b` | $2.70 | _not published_ | $3.375 (1.25× input) | $2.70 |
-| `llama-3.1-70b` | $0.59 | _not published_ | $0.7375 (1.25× input) | $0.79 |
-| `llama-3.1-8b` | $0.05 | _not published_ | $0.0625 (1.25× input) | $0.08 |
-
-## DeepSeek
-
-**Source:** _not recorded_  
-**Verified:** _not recorded_
-
-> **These rates are disputed.** Checked 2026-08-04 against [published pricing](https://api-docs.deepseek.com/quick_start/pricing).
->
-> None of the built-in DeepSeek models appear on the current pricing page, which lists deepseek-v4-flash and deepseek-v4-pro. DeepSeek has also announced peak-hour pricing at 2x standard rates, with an effective date still pending, which the built-in table does not model.
->
-> Treat the rates below as unreliable until they are corrected.
-
-| Model | Input | Cache read | Cache write | Output |
-|---|---|---|---|---|
-| `deepseek-v3` | $0.27 | $0.014 | $0.3375 (1.25× input) | $1.10 |
-| `deepseek-r1` | $0.55 | _not published_ | $0.6875 (1.25× input) | $2.19 |
-| `deepseek-coder` | $0.14 | _not published_ | $0.175 (1.25× input) | $0.28 |
+Intentionally unpriced. Meta publishes no generally available first-party API pricing and its direct Llama API remains waitlisted. Llama rates come from third-party hosts that differ from each other, so no single rate can be sourced. Llama usage stays outside priced totals as an unknown model. Set a custom price for the host you use.
 
 ## Scheduled rate changes
 

--- a/docs/pricing-sources.json
+++ b/docs/pricing-sources.json
@@ -40,47 +40,31 @@
     },
     "google": {
       "label": "Google",
-      "source": null,
-      "url": null,
-      "verified": null,
-      "disputed": {
-        "checked": "2026-08-04",
-        "against": "https://ai.google.dev/gemini-api/docs/pricing",
-        "summary": "Built-in rates disagree with currently published pricing. gemini-2.5-flash is listed at $0.075 / $0.30 against a published $0.30 / $2.50, and gemini-3-flash at $0.15 / $0.60 against a published $1.50 / $9.00. gemini-2.5-pro input and output match the published short-context tier, but its cache-read rate does not. gemini-1.5-pro and gemini-1.5-flash no longer appear on the pricing page. Gemini also tiers rates above 200k context, which the built-in table does not model."
-      }
+      "source": "ai.google.dev Gemini API pricing",
+      "url": "https://ai.google.dev/gemini-api/docs/pricing",
+      "verified": "2026-08-04",
+      "note": "Short-context (<=200k) text tier. Gemini prices audio input and >200k context higher; those tiers are not modeled, so such usage is under-valued rather than guessed."
     },
     "mistral": {
       "label": "Mistral",
-      "source": null,
-      "url": null,
-      "verified": null,
-      "disputed": {
-        "checked": "2026-08-04",
-        "against": "https://mistral.ai/pricing/api/",
-        "summary": "The built-in table prices the floating `-latest` aliases at rates from an older model generation. Published pricing lists Mistral Large 3 at $0.50 / $1.50 against a built-in $2.00 / $6.00, and Mistral Medium 3.5 at $1.50 / $7.50 against a built-in $0.40 / $4.00. Mistral now publishes a cache-read rate at a 90 percent discount, which the built-in table records as 0. `codestral` no longer appears on the pricing page."
-      }
+      "source": "mistral.ai/pricing/api",
+      "url": "https://mistral.ai/pricing/api/",
+      "verified": "2026-08-04",
+      "note": "The floating -latest aliases are priced against the current generation they resolve to. Cache read is Mistral's published 90 percent discount."
     },
     "meta": {
       "label": "Meta",
       "source": null,
       "url": null,
       "verified": null,
-      "disputed": {
-        "checked": "2026-08-04",
-        "against": null,
-        "summary": "Meta publishes no generally available first-party API pricing; its direct Llama API remains waitlisted. Llama rates come from third-party hosts such as DeepInfra, Groq, and Together, differ between them, and move over time, so no single authoritative rate exists to cite. The built-in numbers cannot be sourced as published Meta pricing."
-      }
+      "note": "Intentionally unpriced. Meta publishes no generally available first-party API pricing and its direct Llama API remains waitlisted. Llama rates come from third-party hosts that differ from each other, so no single rate can be sourced. Llama usage stays outside priced totals as an unknown model. Set a custom price for the host you use."
     },
     "deepseek": {
       "label": "DeepSeek",
-      "source": null,
-      "url": null,
-      "verified": null,
-      "disputed": {
-        "checked": "2026-08-04",
-        "against": "https://api-docs.deepseek.com/quick_start/pricing",
-        "summary": "None of the built-in DeepSeek models appear on the current pricing page, which lists deepseek-v4-flash and deepseek-v4-pro. DeepSeek has also announced peak-hour pricing at 2x standard rates, with an effective date still pending, which the built-in table does not model."
-      }
+      "source": "api-docs.deepseek.com pricing",
+      "url": "https://api-docs.deepseek.com/quick_start/pricing",
+      "verified": "2026-08-04",
+      "note": "Standard rates. Announced peak-hour pricing at 2x has no published effective date and is not modeled, so peak usage is under-valued rather than guessed."
     }
   },
   "scheduledChanges": [
@@ -88,7 +72,10 @@
       "model": "claude-sonnet-5",
       "effective": "2026-08-31",
       "note": "Introductory $2 input / $10 output applies through 2026-08-31, then reverts to the $3 / $15 sticker price.",
-      "expectedAfter": { "input": 3.0, "output": 15.0 }
+      "expectedAfter": {
+        "input": 3.0,
+        "output": 15.0
+      }
     }
   ]
 }

--- a/scripts/generate-pricing-table.mjs
+++ b/scripts/generate-pricing-table.mjs
@@ -91,8 +91,8 @@ function buildPage() {
   lines.push('it marks `~$` precisely because it is not a bill. See');
   lines.push('[the pricing methodology](PRICING.md) for how that distinction is enforced.');
   lines.push('');
-  lines.push(`${PRICES.length} models across ${byProvider.size} providers.`);
-  lines.push(`${sourced.length} providers are sourced and verified.`);
+  lines.push(`${PRICES.length} models across ${byProvider.size} priced providers.`);
+  lines.push(`${sourced.filter((id) => byProvider.has(id)).length} of ${byProvider.size} are sourced and verified.`);
   if (disputed.length) {
     lines.push('');
     lines.push(`> **${disputed.length} providers below carry disputed rates.** ` +
@@ -132,6 +132,25 @@ function buildPage() {
       lines.push(`| \`${price.model}\` | ${usd(price.input)} | ${cacheRate(price.cached)} | ${cacheWriteFor(price)} | ${usd(price.output)} |`);
     }
     lines.push('');
+  }
+
+  // A provider listed in the sources file with no priced models is a
+  // deliberate decision, not an oversight. Say so, rather than letting it
+  // vanish from the page.
+  const unpriced = Object.keys(sources.providers).filter((id) => !byProvider.has(id));
+  if (unpriced.length) {
+    lines.push('## Intentionally unpriced');
+    lines.push('');
+    lines.push('Tokimeter ships no rate for these. Their usage is treated as an unknown model:');
+    lines.push('excluded from priced totals rather than valued at a number that cannot be sourced.');
+    lines.push('');
+    for (const id of unpriced) {
+      const meta = providerMeta(id);
+      lines.push(`### ${meta.label}`);
+      lines.push('');
+      lines.push(meta.note || 'No published rate could be sourced.');
+      lines.push('');
+    }
   }
 
   if (sources.scheduledChanges.length) {

--- a/tokimeter/optimizer.py
+++ b/tokimeter/optimizer.py
@@ -65,17 +65,14 @@ DOWNGRADE_PATHS: dict[str, list[tuple[str, float]]] = {
     "grok-3": [
         ("grok-3-mini", 0.88),
     ],
-    "deepseek-r1": [
-        ("deepseek-v3", 0.92),
-    ],
-    "mistral-large-latest": [
-        ("mistral-small-latest", 0.90),
+    # deepseek-r1 -> deepseek-v3 and llama-3.1-405b -> llama-3.1-70b were
+    # dropped with their prices. A downgrade to an unpriced model would produce
+    # a savings number with nothing behind it.
+    "mistral-medium-3.5": [
+        ("mistral-small-4", 0.90),
     ],
     "command-r-plus": [
         ("command-r", 0.92),
-    ],
-    "llama-3.1-405b": [
-        ("llama-3.1-70b", 0.90),
     ],
     "glm-5-plus": [
         ("glm-5-air", 0.90),

--- a/tokimeter/pricing.py
+++ b/tokimeter/pricing.py
@@ -85,44 +85,51 @@ ANTHROPIC_PRICES = [
 
 # ─── Google Gemini ──────────────────────────────────────────────────────────
 
+# Verified against ai.google.dev/gemini-api/docs/pricing, 2026-08-04, at the
+# short-context (<=200k) text tier. Gemini prices audio input and >200k context
+# higher; those tiers are not modeled, so such usage is under-valued rather
+# than guessed.
 GOOGLE_PRICES = [
-    # Gemini 2.5 series
-    ModelPrice("google", "gemini-2.5-pro",          1.25,  10.00, 0.3125,
+    ModelPrice("google", "gemini-3.6-flash",        1.50,  7.50,  0.15),
+    ModelPrice("google", "gemini-3.5-flash",        1.50,  9.00,  0.15,
+               ("gemini-3-flash",)),
+    ModelPrice("google", "gemini-3.5-flash-lite",   0.30,  2.50,  0.03,
+               ("gemini-3-flash-lite",)),
+    ModelPrice("google", "gemini-3.1-flash-lite",   0.25,  1.50,  0.025),
+    ModelPrice("google", "gemini-3.1-pro-preview",  2.00,  12.00, 0.20,
+               ("gemini-3-pro", "gemini-3.5-pro")),
+    ModelPrice("google", "gemini-2.5-pro",          1.25,  10.00, 0.125,
                ("gemini-2.5-pro-preview",)),
-    ModelPrice("google", "gemini-2.5-flash",        0.075, 0.30, 0.01875,
+    ModelPrice("google", "gemini-2.5-flash",        0.30,  2.50,  0.03,
                ("gemini-2.5-flash-preview",)),
-    # Gemini 3.x series (via Velros / Vertex)
-    ModelPrice("google", "gemini-3-pro",            2.50,  15.00, 0.625,
-               ("gemini-3.1-pro-preview", "gemini-3.5-pro")),
-    ModelPrice("google", "gemini-3-flash",          0.15,   0.60, 0.0375,
-               ("gemini-3.5-flash",)),
-    ModelPrice("google", "gemini-3-flash-lite",     0.075,  0.30, 0.01875),
-    # Older
-    ModelPrice("google", "gemini-1.5-pro",          1.25,   5.00, 0.3125),
-    ModelPrice("google", "gemini-1.5-flash",        0.075,  0.30, 0.01875),
-    ModelPrice("google", "gemini-1.5-flash-8b",     0.0375, 0.15),
+    ModelPrice("google", "gemini-2.5-flash-lite",   0.10,  0.40,  0.01),
 ]
 
 # ─── Mistral ────────────────────────────────────────────────────────────────
 
+# Verified against mistral.ai/pricing/api, 2026-08-04. The floating -latest
+# aliases resolve to the current generation. Cache read is a 90% discount.
 MISTRAL_PRICES = [
-    ModelPrice("mistral", "mistral-large-latest",   2.00, 6.00),
-    ModelPrice("mistral", "mistral-medium-latest",  0.40, 4.00),
-    ModelPrice("mistral", "mistral-small-latest",   0.20, 0.60),
-    ModelPrice("mistral", "codestral",              0.30, 0.90),
+    ModelPrice("mistral", "mistral-large-3",        0.50, 1.50, 0.05,
+               ("mistral-large-latest",)),
+    ModelPrice("mistral", "mistral-medium-3.5",     1.50, 7.50, 0.15,
+               ("mistral-medium-latest",)),
+    ModelPrice("mistral", "mistral-small-4",        0.15, 0.60, 0.015,
+               ("mistral-small-latest",)),
+    ModelPrice("mistral", "ministral-3-3b",         0.10, 0.10, 0.01),
+    ModelPrice("mistral", "ministral-3-8b",         0.15, 0.15, 0.015),
+    ModelPrice("mistral", "ministral-3-14b",        0.20, 0.20, 0.02),
     ModelPrice("mistral", "mistral-embed",          0.12, 0.0),
 ]
 
 # ─── Meta Llama (via Together / Groq / Replicate) ──────────────────────────
 
-LLAMA_PRICES = [
-    ModelPrice("meta", "llama-4-scout",    0.20, 0.60),
-    ModelPrice("meta", "llama-4-maverick", 0.27, 0.85),
-    ModelPrice("meta", "llama-3.3-70b",    0.59, 0.79),
-    ModelPrice("meta", "llama-3.1-405b",   2.70, 2.70),
-    ModelPrice("meta", "llama-3.1-70b",    0.59, 0.79),
-    ModelPrice("meta", "llama-3.1-8b",     0.05, 0.08),
-]
+# Intentionally empty. Meta publishes no generally available first-party API
+# pricing; its direct Llama API remains waitlisted. Llama rates come from
+# third-party hosts that differ from each other and change over time, so no
+# single rate can be sourced. Llama usage stays outside priced totals as an
+# unknown model, the same treatment every other unsourced model gets.
+LLAMA_PRICES = []
 
 # ─── xAI Grok ───────────────────────────────────────────────────────────────
 
@@ -138,10 +145,12 @@ XAI_PRICES = [
 
 # ─── DeepSeek ───────────────────────────────────────────────────────────────
 
+# Verified against api-docs.deepseek.com/quick_start/pricing, 2026-08-04.
+# Announced peak-hour pricing at 2x standard rates has no effective date yet
+# and is not modeled, so peak usage is under-valued rather than guessed.
 DEEPSEEK_PRICES = [
-    ModelPrice("deepseek", "deepseek-v3",          0.27, 1.10, 0.014),
-    ModelPrice("deepseek", "deepseek-r1",          0.55, 2.19),
-    ModelPrice("deepseek", "deepseek-coder",       0.14, 0.28),
+    ModelPrice("deepseek", "deepseek-v4-flash",    0.14,  0.28, 0.0028),
+    ModelPrice("deepseek", "deepseek-v4-pro",      0.435, 0.87, 0.003625),
 ]
 
 # ─── Cohere ─────────────────────────────────────────────────────────────────

--- a/ts/packages/core/src/pricing.js
+++ b/ts/packages/core/src/pricing.js
@@ -80,29 +80,46 @@ const PRICES = [
   { provider: "anthropic", model: "claude-3-haiku",          input: 0.25,  output: 1.25,  cached: 0 },
 
   // ─── Google Gemini ────────────────────────────────────────────────────────
-  { provider: "google", model: "gemini-2.5-pro",          input: 1.25,  output: 10.00, cached: 0.3125 },
-  { provider: "google", model: "gemini-2.5-flash",        input: 0.075, output: 0.30,  cached: 0.01875 },
-  { provider: "google", model: "gemini-3-pro",            input: 2.50,  output: 15.00, cached: 0.625,
-    aliases: ["gemini-3.1-pro-preview", "gemini-3.5-pro"] },
-  { provider: "google", model: "gemini-3-flash",          input: 0.15,  output: 0.60,  cached: 0.0375,
-    aliases: ["gemini-3.5-flash"] },
-  { provider: "google", model: "gemini-3-flash-lite",     input: 0.075, output: 0.30,  cached: 0.01875 },
-  { provider: "google", model: "gemini-1.5-pro",          input: 1.25,  output: 5.00,  cached: 0.3125 },
-  { provider: "google", model: "gemini-1.5-flash",        input: 0.075, output: 0.30,  cached: 0.01875 },
+  // Verified against ai.google.dev/gemini-api/docs/pricing, 2026-08-04, at the
+  // short-context (<=200k) text tier, matching the convention used for OpenAI
+  // above. Gemini prices audio input and >200k context higher; Tokimeter does
+  // not model those tiers, so long-context and audio usage is under-valued
+  // rather than guessed.
+  { provider: "google", model: "gemini-3.6-flash",        input: 1.50,  output: 7.50,  cached: 0.15 },
+  { provider: "google", model: "gemini-3.5-flash",        input: 1.50,  output: 9.00,  cached: 0.15,
+    aliases: ["gemini-3-flash"] },
+  { provider: "google", model: "gemini-3.5-flash-lite",   input: 0.30,  output: 2.50,  cached: 0.03,
+    aliases: ["gemini-3-flash-lite"] },
+  { provider: "google", model: "gemini-3.1-flash-lite",   input: 0.25,  output: 1.50,  cached: 0.025 },
+  { provider: "google", model: "gemini-3.1-pro-preview",  input: 2.00,  output: 12.00, cached: 0.20,
+    aliases: ["gemini-3-pro", "gemini-3.5-pro"] },
+  { provider: "google", model: "gemini-2.5-pro",          input: 1.25,  output: 10.00, cached: 0.125 },
+  { provider: "google", model: "gemini-2.5-flash",        input: 0.30,  output: 2.50,  cached: 0.03 },
+  { provider: "google", model: "gemini-2.5-flash-lite",   input: 0.10,  output: 0.40,  cached: 0.01 },
 
   // ─── Mistral ──────────────────────────────────────────────────────────────
-  { provider: "mistral", model: "mistral-large-latest",   input: 2.00, output: 6.00, cached: 0 },
-  { provider: "mistral", model: "mistral-medium-latest",  input: 0.40, output: 4.00, cached: 0 },
-  { provider: "mistral", model: "mistral-small-latest",   input: 0.20, output: 0.60, cached: 0 },
-  { provider: "mistral", model: "codestral",              input: 0.30, output: 0.90, cached: 0 },
+  // Verified against mistral.ai/pricing/api, 2026-08-04. The floating -latest
+  // aliases resolve to the current generation, so they are priced against it.
+  // Mistral publishes cache-read at a 90% discount on input.
+  { provider: "mistral", model: "mistral-large-3",        input: 0.50, output: 1.50, cached: 0.05,
+    aliases: ["mistral-large-latest"] },
+  { provider: "mistral", model: "mistral-medium-3.5",     input: 1.50, output: 7.50, cached: 0.15,
+    aliases: ["mistral-medium-latest"] },
+  { provider: "mistral", model: "mistral-small-4",        input: 0.15, output: 0.60, cached: 0.015,
+    aliases: ["mistral-small-latest"] },
+  { provider: "mistral", model: "ministral-3-3b",         input: 0.10, output: 0.10, cached: 0.01 },
+  { provider: "mistral", model: "ministral-3-8b",         input: 0.15, output: 0.15, cached: 0.015 },
+  { provider: "mistral", model: "ministral-3-14b",        input: 0.20, output: 0.20, cached: 0.02 },
 
   // ─── Meta Llama ───────────────────────────────────────────────────────────
-  { provider: "meta", model: "llama-4-scout",    input: 0.20, output: 0.60, cached: 0 },
-  { provider: "meta", model: "llama-4-maverick", input: 0.27, output: 0.85, cached: 0 },
-  { provider: "meta", model: "llama-3.3-70b",    input: 0.59, output: 0.79, cached: 0 },
-  { provider: "meta", model: "llama-3.1-405b",   input: 2.70, output: 2.70, cached: 0 },
-  { provider: "meta", model: "llama-3.1-70b",    input: 0.59, output: 0.79, cached: 0 },
-  { provider: "meta", model: "llama-3.1-8b",     input: 0.05, output: 0.08, cached: 0 },
+  // Intentionally unpriced. Meta publishes no generally available first-party
+  // API pricing; its direct Llama API remains waitlisted. Llama rates come from
+  // third-party hosts such as DeepInfra, Groq, and Together, differ between
+  // them, and move over time, so no single rate can be sourced as "the" Llama
+  // price. Llama usage therefore stays outside priced totals as an unknown
+  // model, which is the same treatment every other unsourced model gets. Add a
+  // custom price for the host you actually use:
+  //   tokimeter pricing set llama-4-maverick --input <in> --output <out>
 
   // ─── xAI Grok ─────────────────────────────────────────────────────────────
   // grok-build: docs.x.ai Code API pricing (verified 2026-07-08); the Grok
@@ -128,9 +145,13 @@ const PRICES = [
   { provider: "xai", model: "grok-2",            input: 2.00, output: 10.00, cached: 0 },
 
   // ─── DeepSeek ─────────────────────────────────────────────────────────────
-  { provider: "deepseek", model: "deepseek-v3",          input: 0.27, output: 1.10, cached: 0.014 },
-  { provider: "deepseek", model: "deepseek-r1",          input: 0.55, output: 2.19, cached: 0 },
-  { provider: "deepseek", model: "deepseek-coder",       input: 0.14, output: 0.28, cached: 0 },
+  // Verified against api-docs.deepseek.com/quick_start/pricing, 2026-08-04.
+  // DeepSeek has announced peak-hour pricing at 2x standard rates (09:00-12:00
+  // and 14:00-18:00 UTC+8) with no effective date published yet. Tokimeter
+  // prices the standard rate and does not model the peak multiplier, so peak
+  // usage is under-valued rather than guessed.
+  { provider: "deepseek", model: "deepseek-v4-flash",    input: 0.14,  output: 0.28, cached: 0.0028 },
+  { provider: "deepseek", model: "deepseek-v4-pro",      input: 0.435, output: 0.87, cached: 0.003625 },
 
   // ─── Cursor ───────────────────────────────────────────────────────────────
   // Composer 2.5 standard tier per cursor.com/docs/models-and-pricing
@@ -203,11 +224,13 @@ const DOWNGRADES = {
   "claude-opus-4":     [{ model: "claude-sonnet-4", quality: 0.95 }, { model: "claude-haiku-4", quality: 0.85 }],
   "claude-sonnet-4":   [{ model: "claude-haiku-4", quality: 0.88 }],
   "gemini-2.5-pro":    [{ model: "gemini-2.5-flash", quality: 0.92 }],
-  "gemini-3-pro":      [{ model: "gemini-3-flash", quality: 0.92 }],
+  "gemini-3.1-pro-preview": [{ model: "gemini-3.5-flash", quality: 0.92 }],
   "grok-4.5":          [{ model: "grok-4-fast", quality: 0.9 }],
   "grok-4":            [{ model: "grok-4-fast", quality: 0.95 }],
-  "deepseek-r1":       [{ model: "deepseek-v3", quality: 0.92 }],
-  "mistral-large-latest": [{ model: "mistral-small-latest", quality: 0.90 }],
+  // deepseek-r1 -> deepseek-v3 and llama-3.1-405b -> llama-3.1-70b were dropped
+  // with their prices. A downgrade to an unpriced model would produce a savings
+  // number with nothing behind it.
+  "mistral-medium-3.5": [{ model: "mistral-small-4", quality: 0.90 }],
 };
 
 // ─── Pricer ─────────────────────────────────────────────────────────────────

--- a/ts/test/pricing.test.js
+++ b/ts/test/pricing.test.js
@@ -199,3 +199,66 @@ test('report JSON separates known totals from unknown-model rough estimates', (t
   assert.equal(report.pricingSources.find((row) => row.name === 'verified built-in').cost, 1);
   assert.equal(report.pricingSources.find((row) => row.name === 'fallback / unpriced').roughEstimateCost, 10);
 });
+
+test('corrected 2026-08-04 rates match published pricing, aliases included', async () => {
+  const { getPrice } = await import(pathToFileURL(PRICING).href);
+
+  // Google, short-context tier per ai.google.dev, verified 2026-08-04.
+  assert.deepEqual(
+    [getPrice('gemini-2.5-flash').input, getPrice('gemini-2.5-flash').output],
+    [0.30, 2.50],
+  );
+  assert.deepEqual(
+    [getPrice('gemini-3.5-flash').input, getPrice('gemini-3.5-flash').output],
+    [1.50, 9.00],
+  );
+  assert.equal(getPrice('gemini-2.5-pro').cached, 0.125);
+  // The pre-correction names stay resolvable as aliases.
+  assert.equal(getPrice('gemini-3-flash').model, 'gemini-3.5-flash');
+  assert.equal(getPrice('gemini-3-pro').model, 'gemini-3.1-pro-preview');
+
+  // Mistral, per mistral.ai/pricing/api, verified 2026-08-04. The floating
+  // -latest aliases must resolve to the generation they actually point at.
+  assert.equal(getPrice('mistral-large-latest').model, 'mistral-large-3');
+  assert.deepEqual(
+    [getPrice('mistral-large-latest').input, getPrice('mistral-large-latest').output],
+    [0.50, 1.50],
+  );
+  assert.equal(getPrice('mistral-medium-latest').input, 1.50);
+  // Cache read is Mistral's published 90% discount, not zero.
+  assert.equal(getPrice('mistral-small-4').cached, 0.015);
+
+  // DeepSeek, per api-docs.deepseek.com, verified 2026-08-04.
+  assert.deepEqual(
+    [getPrice('deepseek-v4-pro').input, getPrice('deepseek-v4-pro').output],
+    [0.435, 0.87],
+  );
+});
+
+test('models without a sourceable published rate stay unpriced', async () => {
+  const { getPrice, PRICES } = await import(pathToFileURL(PRICING).href);
+
+  // Meta publishes no first-party API pricing, so Llama must not carry an
+  // invented built-in rate. Unknown beats guessed.
+  assert.equal(PRICES.some((price) => price.provider === 'meta'), false);
+  for (const model of ['llama-4-maverick', 'llama-3.1-405b']) {
+    assert.equal(getPrice(model), null, `${model} must not resolve to a built-in price`);
+  }
+
+  // Models delisted from their provider's pricing page go with them, rather
+  // than lingering at a rate that can no longer be verified.
+  for (const model of ['deepseek-v3', 'deepseek-r1', 'gemini-1.5-flash', 'codestral']) {
+    assert.equal(getPrice(model), null, `${model} must not resolve to a built-in price`);
+  }
+});
+
+test('every downgrade suggestion points at a model that is actually priced', async () => {
+  const { DOWNGRADES, getPrice } = await import(pathToFileURL(PRICING).href);
+
+  for (const [from, options] of Object.entries(DOWNGRADES)) {
+    assert.ok(getPrice(from), `downgrade source ${from} is not priced`);
+    for (const option of options) {
+      assert.ok(getPrice(option.model), `${from} suggests unpriced ${option.model}`);
+    }
+  }
+});


### PR DESCRIPTION
Fixes the four providers flagged in #42. All rates verified 2026-08-04 against each provider's published pricing.

## Corrections

| Model | Was | Now | Source |
|---|---|---|---|
| `gemini-2.5-flash` | $0.075 / $0.30 | $0.30 / $2.50 | [ai.google.dev](https://ai.google.dev/gemini-api/docs/pricing) |
| `gemini-3-flash` → `gemini-3.5-flash` | $0.15 / $0.60 | $1.50 / $9.00 | same |
| `gemini-3-pro` → `gemini-3.1-pro-preview` | $2.50 / $15.00 | $2.00 / $12.00 | same |
| `gemini-2.5-pro` cache read | $0.3125 | $0.125 | same |
| `mistral-large-latest` → `mistral-large-3` | $2.00 / $6.00 | $0.50 / $1.50 | [mistral.ai](https://mistral.ai/pricing/api/) |
| `mistral-medium-latest` → `mistral-medium-3.5` | $0.40 / $4.00 | $1.50 / $7.50 | same |
| `deepseek-v3` / `r1` / `coder` | various | `deepseek-v4-flash`, `deepseek-v4-pro` | [api-docs.deepseek.com](https://api-docs.deepseek.com/quick_start/pricing) |

Every pre-correction name is kept as an alias, so existing recorded usage still resolves.

Mistral's published cache-read discount (90%) is now recorded; it was previously `0`, which the engine reads as "not published".

## Meta Llama is now intentionally unpriced

Meta publishes no generally available first-party API pricing and its direct Llama API remains waitlisted. Llama rates come from third-party hosts that differ from each other and change over time, so there is no rate to source.

Rather than keep numbers that cannot be cited, Llama usage now falls to the unknown-model path: excluded from priced totals, shown separately as a rough estimate. That is exactly what the project already does with every other unsourceable model, and `docs/PRICES.md` documents the decision in a new "Intentionally unpriced" section so it is visible rather than a silent omission.

Users on a specific host can set a real price:

```bash
tokimeter pricing set llama-4-maverick --input <in> --output <out>
```

## Not modeled, and said so

- Gemini tiers above 200k context and prices audio input higher. Rates use the short-context text tier, matching the existing OpenAI convention.
- DeepSeek has announced 2x peak-hour pricing with no published effective date.

Both are under-valuations rather than guesses, and both are noted in the code and on the page.

## Downgrade integrity

`deepseek-r1 → deepseek-v3` and `llama-3.1-405b → llama-3.1-70b` are removed. A downgrade suggestion pointing at an unpriced model would produce a savings figure with nothing behind it. A new test asserts every downgrade source and target is actually priced.

## Verification

JavaScript and Python tables updated together, with regression tests for corrected rates, alias resolution, models that must stay unpriced, and downgrade integrity.

```
node scripts/generate-pricing-table.mjs --check   # passed, 8 of 8 priced providers verified
node scripts/privacy-check.mjs --ci               # passed, tarball still 11 files
python3 tests/test_basic.py                       # 30 passed, 0 failed
cd ts && npm test                                 # 126 passed, 0 failed
```