### PR TITLE
Re-verify the remaining providers and correct four more rates

### DIFF
--- a/docs/PRICES.md
+++ b/docs/PRICES.md
@@ -10,20 +10,22 @@ it marks `~$` precisely because it is not a bill. See
 [the pricing methodology](PRICING.md) for how that distinction is enforced.
 
 62 models across 8 priced providers.
-8 of 8 are sourced and verified.
+7 of 8 are sourced and verified.
+
+> **1 providers below carry disputed rates.** Cursor were checked against their published pricing and did not match. Their sections say so, and their numbers should not be relied on until they are corrected. They are listed here rather than quietly omitted because hiding them would be the dishonest option.
 
 ## OpenAI
 
 **Source:** [developers.openai.com/api/docs/pricing](https://developers.openai.com/api/docs/pricing)  
-**Verified:** 2026-07-08
+**Verified:** 2026-08-04
 
-GPT-5.6 Sol/Terra/Luna tiers verified 2026-07-11 at short-context standard rates.
+Standard (non-batch) text rates. o1-mini and gpt-4-turbo are no longer listed and keep their last published rates for older tracked usage.
 
 | Model | Input | Cache read | Cache write | Output |
 |---|---|---|---|---|
 | `gpt-5.6-sol` | $5.00 | $0.50 | $6.25 | $30.00 |
-| `gpt-5.6-terra` | $2.50 | $0.25 | $3.125 | $15.00 |
-| `gpt-5.6-luna` | $1.00 | $0.10 | $1.25 | $6.00 |
+| `gpt-5.6-terra` | $2.00 | $0.20 | $2.50 | $12.00 |
+| `gpt-5.6-luna` | $0.20 | $0.02 | $0.25 | $1.20 |
 | `gpt-5.5` | $5.00 | $0.50 | $6.25 (1.25× input) | $30.00 |
 | `gpt-5.4` | $2.50 | $0.25 | $3.125 (1.25× input) | $15.00 |
 | `gpt-5.4-mini` | $0.75 | $0.075 | $0.9375 (1.25× input) | $4.50 |
@@ -35,16 +37,18 @@ GPT-5.6 Sol/Terra/Luna tiers verified 2026-07-11 at short-context standard rates
 | `gpt-4.1-nano` | $0.10 | $0.025 | $0.125 (1.25× input) | $0.40 |
 | `o1` | $15.00 | $7.50 | $18.75 (1.25× input) | $60.00 |
 | `o1-mini` | $1.10 | $0.55 | $1.375 (1.25× input) | $4.40 |
-| `o3` | $10.00 | $5.00 | $12.50 (1.25× input) | $40.00 |
+| `o3` | $2.00 | $0.50 | $2.50 (1.25× input) | $8.00 |
 | `o3-mini` | $1.10 | $0.55 | $1.375 (1.25× input) | $4.40 |
-| `o4-mini` | $1.10 | $0.55 | $1.375 (1.25× input) | $4.40 |
+| `o4-mini` | $1.10 | $0.275 | $1.375 (1.25× input) | $4.40 |
 | `gpt-4-turbo` | $10.00 | _not published_ | $12.50 (1.25× input) | $30.00 |
 | `gpt-3.5-turbo` | $0.50 | _not published_ | $0.625 (1.25× input) | $1.50 |
 
 ## Anthropic
 
-**Source:** Anthropic pricing and model documentation  
-**Verified:** 2026-07-30
+**Source:** [platform.claude.com pricing](https://platform.claude.com/docs/en/about-claude/pricing)  
+**Verified:** 2026-08-04
+
+Cache read is 0.1x input; cache write is the 5-minute-TTL rate at 1.25x input. Re-verified with no changes.
 
 | Model | Input | Cache read | Cache write | Output |
 |---|---|---|---|---|
@@ -96,16 +100,16 @@ The floating -latest aliases are priced against the current generation they reso
 
 ## xAI
 
-**Source:** [docs.x.ai Chat and Code API pricing](https://docs.x.ai)  
-**Verified:** 2026-07-08
+**Source:** [docs.x.ai models pricing](https://docs.x.ai/docs/models)  
+**Verified:** 2026-08-04
 
-grok-4.5 flagship rates verified 2026-07-11.
+Rates use the <200k context tier; xAI charges double above it and that tier is not modeled. Models below grok-4.3 are no longer listed and keep their last published rates.
 
 | Model | Input | Cache read | Cache write | Output |
 |---|---|---|---|---|
-| `grok-build` | $1.00 | _not published_ | $1.25 (1.25× input) | $2.00 |
-| `grok-4.5` | $2.00 | _not published_ | $2.50 (1.25× input) | $6.00 |
-| `grok-4.3` | $1.25 | _not published_ | $1.5625 (1.25× input) | $2.50 |
+| `grok-build` | $1.00 | $0.20 | $1.25 (1.25× input) | $2.00 |
+| `grok-4.5` | $2.00 | $0.30 | $2.50 (1.25× input) | $6.00 |
+| `grok-4.3` | $1.25 | $0.20 | $1.5625 (1.25× input) | $2.50 |
 | `grok-composer-2.5-fast` | $3.00 | _not published_ | $3.75 (1.25× input) | $15.00 |
 | `grok-4` | $5.00 | _not published_ | $6.25 (1.25× input) | $15.00 |
 | `grok-4-fast` | $0.20 | _not published_ | $0.25 (1.25× input) | $0.50 |
@@ -125,21 +129,12 @@ Standard rates. Announced peak-hour pricing at 2x has no published effective dat
 | `deepseek-v4-flash` | $0.14 | $0.0028 | $0.175 (1.25× input) | $0.28 |
 | `deepseek-v4-pro` | $0.435 | $0.0036 | $0.5437 (1.25× input) | $0.87 |
 
-## Cursor
-
-**Source:** [cursor.com/docs/models-and-pricing](https://cursor.com/docs/models-and-pricing)  
-**Verified:** 2026-07-08
-
-Composer 2.5 standard tier. The fast tier is priced under xAI.
-
-| Model | Input | Cache read | Cache write | Output |
-|---|---|---|---|---|
-| `composer-2.5` | $0.50 | $0.20 | $0.625 (1.25× input) | $2.50 |
-
 ## Z.AI
 
-**Source:** [docs.z.ai pricing](https://docs.z.ai)  
-**Verified:** 2026-07-08
+**Source:** [docs.z.ai pricing](https://docs.z.ai/guides/overview/pricing)  
+**Verified:** 2026-08-04
+
+glm-5.2 verified. The other GLM entries are no longer listed and keep their last published rates for older tracked usage.
 
 | Model | Input | Cache read | Cache write | Output |
 |---|---|---|---|---|
@@ -149,6 +144,21 @@ Composer 2.5 standard tier. The fast tier is priced under xAI.
 | `glm-5-flash` | $0.10 | _not published_ | $0.125 (1.25× input) | $0.10 |
 | `glm-4-plus` | $0.50 | _not published_ | $0.625 (1.25× input) | $1.50 |
 | `glm-4-flash` | $0.01 | _not published_ | $0.0125 (1.25× input) | $0.01 |
+
+## Cursor
+
+**Source:** _not recorded_  
+**Verified:** _not recorded_
+
+> **These rates are disputed.** Checked 2026-08-04 against [published pricing](https://cursor.com/docs/models-and-pricing).
+>
+> Cursor no longer publishes per-token rates for its own models. The Composer 2.5 rate here was sourced on 2026-07-08 but can no longer be verified against any published figure, so it should be treated as historical rather than current.
+>
+> Treat the rates below as unreliable until they are corrected.
+
+| Model | Input | Cache read | Cache write | Output |
+|---|---|---|---|---|
+| `composer-2.5` | $0.50 | $0.20 | $0.625 (1.25× input) | $2.50 |
 
 ## Intentionally unpriced
 
@@ -167,7 +177,7 @@ cannot quietly go stale.
 
 | Model | Effective | Change |
 |---|---|---|
-| `claude-sonnet-5` | 2026-08-31 | Introductory $2 input / $10 output applies through 2026-08-31, then reverts to the $3 / $15 sticker price. |
+| `claude-sonnet-5` | 2026-08-31 | Introductory $2 input / $10 output applies through 2026-08-31, then reverts to $3 / $15 with cache read $0.30 and 5-minute cache write $3.75. |
 
 ## How to read this
 

--- a/docs/pricing-sources.json
+++ b/docs/pricing-sources.json
@@ -7,36 +7,40 @@
       "label": "OpenAI",
       "source": "developers.openai.com/api/docs/pricing",
       "url": "https://developers.openai.com/api/docs/pricing",
-      "verified": "2026-07-08",
-      "note": "GPT-5.6 Sol/Terra/Luna tiers verified 2026-07-11 at short-context standard rates."
+      "verified": "2026-08-04",
+      "note": "Standard (non-batch) text rates. o1-mini and gpt-4-turbo are no longer listed and keep their last published rates for older tracked usage."
     },
     "anthropic": {
       "label": "Anthropic",
-      "source": "Anthropic pricing and model documentation",
-      "url": null,
-      "verified": "2026-07-30",
-      "note": null
+      "source": "platform.claude.com pricing",
+      "url": "https://platform.claude.com/docs/en/about-claude/pricing",
+      "verified": "2026-08-04",
+      "note": "Cache read is 0.1x input; cache write is the 5-minute-TTL rate at 1.25x input. Re-verified with no changes."
     },
     "xai": {
       "label": "xAI",
-      "source": "docs.x.ai Chat and Code API pricing",
-      "url": "https://docs.x.ai",
-      "verified": "2026-07-08",
-      "note": "grok-4.5 flagship rates verified 2026-07-11."
+      "source": "docs.x.ai models pricing",
+      "url": "https://docs.x.ai/docs/models",
+      "verified": "2026-08-04",
+      "note": "Rates use the <200k context tier; xAI charges double above it and that tier is not modeled. Models below grok-4.3 are no longer listed and keep their last published rates."
     },
     "cursor": {
       "label": "Cursor",
-      "source": "cursor.com/docs/models-and-pricing",
-      "url": "https://cursor.com/docs/models-and-pricing",
-      "verified": "2026-07-08",
-      "note": "Composer 2.5 standard tier. The fast tier is priced under xAI."
+      "source": null,
+      "url": null,
+      "verified": null,
+      "disputed": {
+        "checked": "2026-08-04",
+        "against": "https://cursor.com/docs/models-and-pricing",
+        "summary": "Cursor no longer publishes per-token rates for its own models. The Composer 2.5 rate here was sourced on 2026-07-08 but can no longer be verified against any published figure, so it should be treated as historical rather than current."
+      }
     },
     "zai": {
       "label": "Z.AI",
       "source": "docs.z.ai pricing",
-      "url": "https://docs.z.ai",
-      "verified": "2026-07-08",
-      "note": null
+      "url": "https://docs.z.ai/guides/overview/pricing",
+      "verified": "2026-08-04",
+      "note": "glm-5.2 verified. The other GLM entries are no longer listed and keep their last published rates for older tracked usage."
     },
     "google": {
       "label": "Google",
@@ -71,10 +75,12 @@
     {
       "model": "claude-sonnet-5",
       "effective": "2026-08-31",
-      "note": "Introductory $2 input / $10 output applies through 2026-08-31, then reverts to the $3 / $15 sticker price.",
+      "note": "Introductory $2 input / $10 output applies through 2026-08-31, then reverts to $3 / $15 with cache read $0.30 and 5-minute cache write $3.75.",
       "expectedAfter": {
         "input": 3.0,
-        "output": 15.0
+        "output": 15.0,
+        "cached": 0.3,
+        "cacheWrite": 3.75
       }
     }
   ]

--- a/scripts/generate-pricing-table.mjs
+++ b/scripts/generate-pricing-table.mjs
@@ -204,7 +204,7 @@ function runChecks() {
       continue;
     }
     const expected = change.expectedAfter || {};
-    for (const field of ['input', 'output']) {
+    for (const field of ['input', 'output', 'cached', 'cacheWrite']) {
       if (typeof expected[field] === 'number' && price[field] !== expected[field]) {
         failures.push(`${change.model} ${field} is still ${price[field]} after ${change.effective}; expected ${expected[field]} (${change.note})`);
       }

--- a/tokimeter/pricing.py
+++ b/tokimeter/pricing.py
@@ -25,12 +25,12 @@ class ModelPrice:
 # ─── OpenAI ─────────────────────────────────────────────────────────────────
 
 OPENAI_PRICES = [
-    # GPT-5.x (verified against developers.openai.com/api/docs/pricing, 2026-07-08;
-    # GPT-5.6 Sol/Terra/Luna verified 2026-07-11 — short-context standard rates,
-    # explicit cache-write pricing at 1.25x input)
+    # Verified against developers.openai.com/api/docs/pricing, 2026-08-04.
+    # 5.6+ publishes explicit cache-write pricing at 1.25x input. o1-mini is no
+    # longer listed and keeps its last published rate for older usage.
     ModelPrice("openai", "gpt-5.6-sol",       5.00,  30.00, 0.50,  (), 6.25),
-    ModelPrice("openai", "gpt-5.6-terra",     2.50,  15.00, 0.25,  (), 3.125),
-    ModelPrice("openai", "gpt-5.6-luna",      1.00,   6.00, 0.10,  (), 1.25),
+    ModelPrice("openai", "gpt-5.6-terra",     2.00,  12.00, 0.20,  (), 3.125),
+    ModelPrice("openai", "gpt-5.6-luna",      0.20,   1.20, 0.02,  (), 0.25),
     ModelPrice("openai", "gpt-5.5",           5.00,  30.00, 0.50),
     ModelPrice("openai", "gpt-5.4",           2.50,  15.00, 0.25),
     ModelPrice("openai", "gpt-5.4-mini",      0.75,   4.50, 0.075),
@@ -44,9 +44,9 @@ OPENAI_PRICES = [
     ModelPrice("openai", "gpt-4.1-nano",      0.10,  0.40, 0.025),
     ModelPrice("openai", "o1",               15.00,  60.00, 7.50),
     ModelPrice("openai", "o1-mini",           1.10,  4.40, 0.55),
-    ModelPrice("openai", "o3",               10.00,  40.00, 5.00),
+    ModelPrice("openai", "o3",                2.00,  8.00, 0.50),
     ModelPrice("openai", "o3-mini",           1.10,  4.40, 0.55),
-    ModelPrice("openai", "o4-mini",           1.10,  4.40, 0.55),
+    ModelPrice("openai", "o4-mini",           1.10,  4.40, 0.275),
     ModelPrice("openai", "gpt-4-turbo",      10.00,  30.00),
     ModelPrice("openai", "gpt-3.5-turbo",     0.50,  1.50),
 ]
@@ -54,7 +54,7 @@ OPENAI_PRICES = [
 # ─── Anthropic ──────────────────────────────────────────────────────────────
 
 ANTHROPIC_PRICES = [
-    # Verified against Anthropic pricing/model docs, 2026-07-30.
+    # Verified against platform.claude.com pricing, 2026-08-04.
     # cached = cache-read (~0.1x input); cache_write = 5-min-TTL cache-write (~1.25x input).
     ModelPrice("anthropic", "claude-fable-5",          10.00, 50.00, 1.00,
                ("claude-mythos-5",), 12.50),
@@ -134,8 +134,9 @@ LLAMA_PRICES = []
 # ─── xAI Grok ───────────────────────────────────────────────────────────────
 
 XAI_PRICES = [
-    # grok-4.5: docs.x.ai flagship (verified 2026-07-11); no cached price published.
-    ModelPrice("xai", "grok-4.5",          2.00,  6.00, 0.0, ("grok-4.5-latest",)),
+    # Verified against docs.x.ai models pricing, 2026-08-04, at the <200k tier.
+    # Models below grok-4.5 are no longer listed and keep last published rates.
+    ModelPrice("xai", "grok-4.5",          2.00,  6.00, 0.30, ("grok-4.5-latest",)),
     ModelPrice("xai", "grok-4",            5.00, 15.00),
     ModelPrice("xai", "grok-4-fast",       0.20, 0.50),
     ModelPrice("xai", "grok-3",            3.00, 15.00),

--- a/ts/packages/core/src/pricing.js
+++ b/ts/packages/core/src/pricing.js
@@ -29,12 +29,12 @@ import { dirname, join } from 'node:path';
 /** @type {ModelPrice[]} */
 const PRICES = [
   // ─── OpenAI ───────────────────────────────────────────────────────────────
-  // GPT-5.x (verified against developers.openai.com/api/docs/pricing, 2026-07-08;
-  // GPT-5.6 Sol/Terra/Luna tiers verified 2026-07-11 — short-context standard rates;
-  // 5.6+ publishes explicit cache-write pricing at 1.25x input)
+  // Verified against developers.openai.com/api/docs/pricing, 2026-08-04.
+  // 5.6+ publishes explicit cache-write pricing at 1.25x input. o1-mini is no
+  // longer listed and is kept at its last published rate for older usage.
   { provider: "openai", model: "gpt-5.6-sol",       input: 5.00,  output: 30.00, cached: 0.50,  cacheWrite: 6.25 },
-  { provider: "openai", model: "gpt-5.6-terra",     input: 2.50,  output: 15.00, cached: 0.25,  cacheWrite: 3.125 },
-  { provider: "openai", model: "gpt-5.6-luna",      input: 1.00,  output: 6.00,  cached: 0.10,  cacheWrite: 1.25 },
+  { provider: "openai", model: "gpt-5.6-terra",     input: 2.00,  output: 12.00, cached: 0.20,  cacheWrite: 2.50 },
+  { provider: "openai", model: "gpt-5.6-luna",      input: 0.20,  output: 1.20,  cached: 0.02,  cacheWrite: 0.25 },
   { provider: "openai", model: "gpt-5.5",           input: 5.00,  output: 30.00, cached: 0.50 },
   { provider: "openai", model: "gpt-5.4",           input: 2.50,  output: 15.00, cached: 0.25 },
   { provider: "openai", model: "gpt-5.4-mini",      input: 0.75,  output: 4.50,  cached: 0.075 },
@@ -48,14 +48,14 @@ const PRICES = [
   { provider: "openai", model: "gpt-4.1-nano",      input: 0.10,  output: 0.40,  cached: 0.025 },
   { provider: "openai", model: "o1",               input: 15.00, output: 60.00, cached: 7.50 },
   { provider: "openai", model: "o1-mini",          input: 1.10,  output: 4.40,  cached: 0.55 },
-  { provider: "openai", model: "o3",               input: 10.00, output: 40.00, cached: 5.00 },
+  { provider: "openai", model: "o3",               input: 2.00,  output: 8.00,  cached: 0.50 },
   { provider: "openai", model: "o3-mini",          input: 1.10,  output: 4.40,  cached: 0.55 },
-  { provider: "openai", model: "o4-mini",          input: 1.10,  output: 4.40,  cached: 0.55 },
+  { provider: "openai", model: "o4-mini",          input: 1.10,  output: 4.40,  cached: 0.275 },
   { provider: "openai", model: "gpt-4-turbo",      input: 10.00, output: 30.00, cached: 0 },
   { provider: "openai", model: "gpt-3.5-turbo",    input: 0.50,  output: 1.50,  cached: 0 },
 
   // ─── Anthropic ────────────────────────────────────────────────────────────
-  // Verified against Anthropic pricing/model docs, 2026-07-30.
+  // Verified against platform.claude.com pricing, 2026-08-04.
   // cached = cache-read rate (~0.1x input); cacheWrite = 5-minute-TTL cache-write rate (~1.25x input).
   { provider: "anthropic", model: "claude-fable-5",          input: 10.00, output: 50.00, cached: 1.00, cacheWrite: 12.50,
     aliases: ["claude-mythos-5"] },
@@ -122,17 +122,21 @@ const PRICES = [
   //   tokimeter pricing set llama-4-maverick --input <in> --output <out>
 
   // ─── xAI Grok ─────────────────────────────────────────────────────────────
-  // grok-build: docs.x.ai Code API pricing (verified 2026-07-08); the Grok
+  // Verified against docs.x.ai models pricing, 2026-08-04, at the <200k tier.
+  // xAI publishes explicit cache-read rates; they were previously recorded as
+  // unpriced. Models below grok-4.3 are no longer listed and keep their last
+  // published rates for older tracked usage.
+  // grok-build: docs.x.ai Code API pricing; the Grok
   // Build CLI reports the model as grok-build / grok-build-b, API id is
   // grok-build-0.1. No cached-input price published → cached tokens free.
-  { provider: "xai", model: "grok-build",        input: 1.00, output: 2.00,  cached: 0,
+  { provider: "xai", model: "grok-build",        input: 1.00, output: 2.00,  cached: 0.20,
     aliases: ["grok-build-0.1", "grok-build-b"] },
   // grok-4.5: docs.x.ai flagship (verified 2026-07-11); $2/$6, 500k context,
   // no cached-input price published → cached tokens free.
-  { provider: "xai", model: "grok-4.5",          input: 2.00, output: 6.00,  cached: 0,
+  { provider: "xai", model: "grok-4.5",          input: 2.00, output: 6.00,  cached: 0.30,
     aliases: ["grok-4.5-latest"] },
   // grok-4.3: docs.x.ai Chat API pricing (verified 2026-07-08).
-  { provider: "xai", model: "grok-4.3",          input: 1.25, output: 2.50,  cached: 0 },
+  { provider: "xai", model: "grok-4.3",          input: 1.25, output: 2.50,  cached: 0.20 },
   // Composer 2.5 fast variant runs inside Grok Build as
   // grok-composer-2.5-fast; $3/$15 per cursor.com/blog/composer-2-5
   // (verified 2026-07-08). No cached price published for the fast tier.

--- a/ts/test/pricing.test.js
+++ b/ts/test/pricing.test.js
@@ -262,3 +262,25 @@ test('every downgrade suggestion points at a model that is actually priced', asy
     }
   }
 });
+
+test('re-verified 2026-08-04 rates match published pricing', async () => {
+  const { getPrice } = await import(pathToFileURL(PRICING).href);
+
+  // OpenAI, per developers.openai.com. These four were wrong before the
+  // 2026-08-04 re-verification; o3 and gpt-5.6-luna by roughly 5x.
+  assert.deepEqual([getPrice('o3').input, getPrice('o3').output], [2.00, 8.00]);
+  assert.equal(getPrice('o3').cached, 0.50);
+  assert.deepEqual([getPrice('gpt-5.6-luna').input, getPrice('gpt-5.6-luna').output], [0.20, 1.20]);
+  assert.deepEqual([getPrice('gpt-5.6-terra').input, getPrice('gpt-5.6-terra').output], [2.00, 12.00]);
+  assert.equal(getPrice('o4-mini').cached, 0.275);
+
+  // xAI publishes cache-read rates; they were previously recorded as unpriced.
+  assert.equal(getPrice('grok-4.5').cached, 0.30);
+  assert.equal(getPrice('grok-4.3').cached, 0.20);
+  assert.equal(getPrice('grok-build').cached, 0.20);
+
+  // Anthropic re-verified with no change, including the introductory rate
+  // still in effect through 2026-08-31.
+  assert.deepEqual([getPrice('claude-sonnet-5').input, getPrice('claude-sonnet-5').output], [2.00, 10.00]);
+  assert.equal(getPrice('claude-opus-5').cacheWrite, 6.25);
+});


### PR DESCRIPTION
Re-checked OpenAI, Anthropic, xAI, Cursor, and Z.AI against published pricing on 2026-08-04. The suspicion that prompted this was right: four more OpenAI rates were wrong, two of them by roughly 5x.

## Corrections

| Model | Was | Published | Off by |
|---|---|---|---|
| `o3` | $10.00 / $40.00 | **$2.00 / $8.00** | 5x |
| `gpt-5.6-luna` | $1.00 / $6.00 | **$0.20 / $1.20** | 5x |
| `gpt-5.6-terra` | $2.50 / $15.00 | **$2.00 / $12.00** | 1.25x |
| `o4-mini` cache read | $0.55 | **$0.275** | 2x |

xAI publishes explicit cache-read rates that were recorded as `0`, which the engine reads as "not published": `grok-4.5` $0.30, `grok-4.3` $0.20, `grok-build` $0.20.

## Clean

**Anthropic** re-verified with no changes, including the Sonnet 5 introductory rate still in effect through 2026-08-31. **Z.AI** `glm-5.2` re-verified unchanged.

## Cursor is now unsourceable

Cursor no longer publishes per-token rates for its own models. The Composer 2.5 rate was sourced on 2026-07-08 but can no longer be verified against any published figure, so it is marked disputed rather than presented as verified.

## Stronger expiry guard

The Sonnet 5 scheduled change now asserts cache-read and cache-write alongside input and output, so the 2026-09-01 revert can't be half-applied:

```
$ TOKIMETER_PRICING_TODAY=2026-09-01 node scripts/generate-pricing-table.mjs --check
- claude-sonnet-5 input is still 2 after 2026-08-31; expected 3
- claude-sonnet-5 output is still 10 after 2026-08-31; expected 15
- claude-sonnet-5 cached is still 0.2 after 2026-08-31; expected 0.3
- claude-sonnet-5 cacheWrite is still 2.5 after 2026-08-31; expected 3.75
```

## Verification

```
node scripts/generate-pricing-table.mjs --check   # passed
node scripts/privacy-check.mjs --ci               # passed, tarball still 11 files
python3 tests/test_basic.py                       # 30 passed, 0 failed
cd ts && npm test                                 # 127 passed, 0 failed
```

One note: a single Python run reported `29 passed, 1 failed` mid-session and I could not reproduce it across 14 consecutive runs afterward. Recording it here rather than omitting it; CI is the real check.

## Still open

Delisted models across OpenAI (`o1-mini`, `gpt-4-turbo`), xAI (`grok-4`, `grok-4-fast`, `grok-3`, `grok-3-mini`, `grok-2`, `grok-composer-2.5-fast`), and Z.AI (five GLM entries) keep their last published rates for older tracked usage rather than being removed. Removing them would drop historical pricing and break downgrade targets, so it needs a separate decision.