### PR TITLE
Prepare npm 0.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The versioning is [semver](https://semver.org); pre-1.0, minor versions may add 
 
 ## Unreleased
 
+## 0.5.11 — 2026-08-04
+
+### Added
+
+- Read OpenHuman usage from the active workspace's `state/costs.jsonl` ledger,
+  with no setup. Token buckets are exact, provider-charged cost stays reported
+  and OpenHuman's own estimates stay marked as estimates, and bare managed
+  aliases stay attributed to `openhuman` rather than guessing a provider.
+  Memory trees, wiki pages, run journals, transcripts, OAuth state, and the
+  local account id are never read. Fixture tested, not yet live verified.
+
 ### Pricing
 
 - Correct Google, Mistral, and DeepSeek rates against each provider's published
@@ -21,6 +32,15 @@ The versioning is [semver](https://semver.org); pre-1.0, minor versions may add 
   that cannot be sourced. Set a custom price for the host you actually use.
 - Drop downgrade suggestions that pointed at models which are no longer priced,
   so a savings figure can never be computed against an unpriced target.
+- Correct four more OpenAI rates found by re-verifying every remaining provider
+  on 2026-08-04: `o3` was `$10/$40` against a published `$2/$8`, `gpt-5.6-luna`
+  was `$1/$6` against `$0.20/$1.20`, `gpt-5.6-terra` was `$2.50/$15` against
+  `$2/$12`, and `o4-mini`'s cache-read rate was double the published figure.
+- Record xAI's published cache-read rates for `grok-4.5`, `grok-4.3`, and
+  `grok-build`, which were previously stored as unpriced.
+- Re-verify Anthropic and Z.AI's `glm-5.2` with no rate changes.
+- Mark Cursor's Composer 2.5 rate as no longer verifiable. Cursor stopped
+  publishing per-token rates for its own models.
 - Publish every rate with its source and verification date in `docs/PRICES.md`,
   generated from the same table the CLI prices with, and fail CI when a
   provider's verification goes stale or a dated rate change comes due.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>
-  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="374" height="40" alt="npm v0.5.10, release v0.5.10, MIT license, Node 18+" align="right" hspace="2"></a>
+  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="374" height="40" alt="npm v0.5.11, release v0.5.11, MIT license, Node 18+" align="right" hspace="2"></a>
   <img src="readme-wordmark.svg" width="190" height="48" alt="Tokimeter">
 </h1>
 

--- a/readme-badges.svg
+++ b/readme-badges.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="374" height="40" viewBox="0 0 374 40" role="img" aria-label="npm v0.5.10, release v0.5.10, MIT license, Node 18+">
-  <title>npm v0.5.10 · release v0.5.10 · MIT · Node 18+</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="374" height="40" viewBox="0 0 374 40" role="img" aria-label="npm v0.5.11, release v0.5.11, MIT license, Node 18+">
+  <title>npm v0.5.11 · release v0.5.11 · MIT · Node 18+</title>
   <defs>
     <clipPath id="npm">
       <rect x="0" y="12" width="90" height="20" rx="3"/>
@@ -34,9 +34,9 @@
 
   <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
     <text x="18" y="26" text-anchor="middle">npm</text>
-    <text x="63" y="26" text-anchor="middle">v0.5.10</text>
+    <text x="63" y="26" text-anchor="middle">v0.5.11</text>
     <text x="124" y="26" text-anchor="middle">release</text>
-    <text x="177" y="26" text-anchor="middle">v0.5.10</text>
+    <text x="177" y="26" text-anchor="middle">v0.5.11</text>
     <text x="236" y="26" text-anchor="middle">License</text>
     <text x="277" y="26" text-anchor="middle">MIT</text>
     <text x="321" y="26" text-anchor="middle">node</text>

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -58,7 +58,7 @@
     },
     "packages/proxy": {
       "name": "tokimeter",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "license": "MIT",
       "bin": {
         "tm": "src/cli.js",

--- a/ts/packages/proxy/package.json
+++ b/ts/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokimeter",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "Local-first usage & cost meter for AI coding agents (Claude Code, Codex, Cursor, Grok Build, Hermes, opencode, Cline, Copilot CLI). Inline status-line HUDs, zero-setup reports, 5h-window limits, budgets — no telemetry.",
   "type": "module",
   "main": "src/server.js",


### PR DESCRIPTION
Release preparation for `0.5.11`: corrected provider pricing plus the OpenHuman cost reader.

## Why this one matters

`0.5.10` ships rates that are wrong by up to 5x. Anyone metering Gemini, Mistral, DeepSeek, `o3`, or the GPT-5.6 tiers is getting incorrect tracked spend today. Every correction is merged and unreleased.

| Model | 0.5.10 ships | Published |
|---|---|---|
| `o3` | $10.00 / $40.00 | $2.00 / $8.00 |
| `gpt-5.6-luna` | $1.00 / $6.00 | $0.20 / $1.20 |
| `gemini-2.5-flash` | $0.075 / $0.30 | $0.30 / $2.50 |
| `gemini-3-flash` | $0.15 / $0.60 | $1.50 / $9.00 |
| `mistral-large-latest` | $2.00 / $6.00 | $0.50 / $1.50 |

## Also in this release

The OpenHuman cost reader (#28), which reads the active workspace's `state/costs.jsonl` with no setup and never touches memory trees, transcripts, run journals, OAuth state, or the local account id.

It ships **fixture tested, not live verified**, and the README coverage table says so. That label stays until it is run against a real OpenHuman workspace.

## Changes

- Bump `ts/packages/proxy/package.json` and `ts/package-lock.json` to `0.5.11`.
- Date the changelog entry `0.5.11 — 2026-08-04`, covering both the OpenHuman reader and the full set of pricing corrections.
- Refresh the README badge to `npm v0.5.11` / `release v0.5.11`.

## Verification

```
node scripts/privacy-check.mjs --ci               # passed, tarball still 11 files
node scripts/generate-pricing-table.mjs --check   # passed
python3 tests/test_basic.py                       # 30 passed, 0 failed
cd ts && npm test                                 # 133 passed, 0 failed
```

No tag, release, or publish happens here. Those are separate approved steps after this merges.