### PR TITLE
Clarify what OpenHuman costs mean

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ the report only observes.
 | Cursor CLI/Desktop Agent | Live verified | Status-line and stop hooks after `tokimeter setup cursor`; CSV import for classic editor chat | Exact per-turn usage after hook setup, local windows, and user-budget warnings. Earlier hookless turns are not reconstructed. |
 | Grok Build | Live verified | Local `~/.grok/logs`; optional stop hook for alarms | Exact recorded per-turn tokens and `~` cost. Local windows and user budgets, not a claimed vendor quota. |
 | Hermes | Live verified | Local `~/.hermes` database; no setup for reports | Provider-recorded session totals and billed cost when present; otherwise priced `~` estimates. |
-| OpenHuman | Fixture tested | Active workspace `state/costs.jsonl`; no setup for reports | Exact recorded token buckets. Provider-charged cost stays reported; OpenHuman estimates stay visibly estimated. Memory and transcript data are never read. |
+| OpenHuman | Fixture tested | Active workspace `state/costs.jsonl`; no setup for reports | Exact recorded token buckets. Costs are per-request model costs, not TinyHumans credit use or your subscription bill. Memory and transcript data are never read. |
 | opencode | Live verified with 1.17.18 | Local message files/database; no setup for reports | Recorded token counts and request-time cost when present; otherwise priced `~` estimates. |
 | Cline | Live verified with CLI 3.0.39 + Codex OAuth | Local task/session history; no setup for reports | Numeric usage and Cline's request-time cost when present. Prompt and response content are ignored. |
 | Copilot CLI / Aider | Fixture tested | Copilot file exporter or Aider history import/proxy | Parser, deduplication, accounting, and privacy behavior pass fixtures; not claimed as live-verified in this release. |
@@ -244,6 +244,13 @@ the local OpenHuman account id used to find the active workspace. A
 as `chat-v1` stay attributed to OpenHuman rather than guessing an underlying
 provider. Use `--tool openhuman` to scope a report. This reader is fixture
 tested, not claimed as live verified.
+
+These are **per-request model costs, not what you pay TinyHumans**. TinyHumans
+bills in credits through a monthly plan or pay-as-you-go top-ups, and a credit
+has no fixed dollar value across tiers. Tokimeter does not read your credit
+balance, credits consumed, or remaining monthly allowance, and it cannot derive
+them from the cost ledger. Read these numbers as what the usage cost at model
+rates, not as an invoice.
 
 **opencode**: tracked automatically, zero setup. opencode stores per-message
 token counts locally (`~/.local/share/opencode`, or `OPENCODE_DATA_DIR`);

--- a/ts/packages/proxy/README.md
+++ b/ts/packages/proxy/README.md
@@ -72,6 +72,12 @@ journals, transcripts, OAuth state, or credentials, and does not retain the
 local account id used for workspace discovery. Bare managed model aliases stay
 attributed to `openhuman`. Scope the report with `--tool openhuman`.
 
+These are per-request model costs, not what you pay TinyHumans. TinyHumans
+bills in credits through a monthly plan or pay-as-you-go top-ups, and a credit
+has no fixed dollar value across tiers. Tokimeter does not read your credit
+balance, credits consumed, or remaining monthly allowance, and cannot derive
+them from the cost ledger.
+
 Claude Code and Codex coverage includes local coding sessions created from
 their CLI and desktop surfaces. Regular Claude or ChatGPT chats and
 remote/cloud-only sessions are outside the report when they do not write


### PR DESCRIPTION
TinyHumans bills in **credits**, not dollars: a monthly plan (Basic $19.99 for 60 credits, Pro $199.99 for 1,800) or pay-as-you-go top-ups. A credit has no fixed dollar value across tiers, so there is no conversion from credits to USD.

The `cost_usd` figures in OpenHuman's ledger are **per-request model costs**. Presenting them without qualification invites a subscriber to read them as an invoice they owe, which they are not. A Basic subscriber paying $19.99/month could see a far larger figure in a report and reasonably conclude it is their bill.

## Changes

Documentation only, no behavior change.

- README coverage row now says costs are per-request model costs, not TinyHumans credit use or your subscription bill.
- Both the public README and the packaged npm README state that Tokimeter does not read credit balance, credits consumed, or remaining monthly allowance, and cannot derive them from the cost ledger.

The packaged README matters here: it is what npm users see on the package page, and it carried the same unqualified claim.

## Deliberately not changed

`provider_charged` still renders as a reported cost with a plain `$`. That is technically correct under the project's convention, since OpenHuman did report it, and changing it is a judgment call about the reported-versus-estimated distinction rather than a documentation fix. Worth revisiting once a real workspace shows which `cost_source` values appear in practice.

## Verification

```
node scripts/privacy-check.mjs --precommit   # passed, tarball still 11 files
python3 tests/test_basic.py                  # 30 passed, 0 failed
cd ts && npm test                            # 133 passed, 0 failed
```