### PR TITLE
Fix the unreadable wordmark on dark mobile themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <h1>
   <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="374" height="40" alt="npm v0.5.11, release v0.5.11, MIT license, Node 18+" align="right" hspace="2"></a>
-  <img src="readme-wordmark.svg" width="190" height="48" alt="Tokimeter">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="readme-wordmark-dark.svg">
+    <img src="readme-wordmark.svg" width="190" height="48" alt="Tokimeter">
+  </picture>
 </h1>
 
 **Local-first usage and cost meter for Claude Code, Codex, Cursor, Grok Build,

--- a/readme-wordmark-dark.svg
+++ b/readme-wordmark-dark.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="190" height="48" viewBox="0 0 190 48" role="img" aria-label="Tokimeter">
+  <title>Tokimeter</title>
+  <style>
+    .word { fill: #f0f6fc; }
+  </style>
+
+  <g transform="translate(0 3) scale(.59375)">
+    <path d="M15 49 A24 24 0 1 1 49 49" fill="none" stroke="#4ade80" stroke-width="9.5" stroke-linecap="round"/>
+    <circle cx="32" cy="56" r="5" fill="#4ade80"/>
+    <line x1="32" y1="32" x2="43.5" y2="20.5" stroke="#4ade80" stroke-width="6" stroke-linecap="round"/>
+    <circle cx="32" cy="32" r="6.5" fill="#4ade80"/>
+  </g>
+
+  <text class="word" x="48" y="34" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="30" font-weight="600" letter-spacing="-.3">Tokimeter</text>
+</svg>


### PR DESCRIPTION
The Tokimeter wordmark renders as near-invisible dark text on GitHub's dark mobile theme, while looking correct on desktop.

## Cause

`readme-wordmark.svg` switched its text colour with `@media (prefers-color-scheme: dark)` **inside the SVG**. An SVG loaded through an `<img>` tag renders in its own document, and the host page's colour scheme does not reliably reach it. GitHub's mobile renderer evaluates the query as light and paints `#1f2328` onto a dark background. Desktop browsers do propagate the preference, which is why the bug only showed on mobile.

## Fix

Add `readme-wordmark-dark.svg` with the light fill baked in and no media query, then select between them with a `<picture>` element:

```html
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="readme-wordmark-dark.svg">
  <img src="readme-wordmark.svg" width="190" height="48" alt="Tokimeter">
</picture>
```

The media query is evaluated by the host page rather than inside the image, which is the mechanism GitHub documents for theme-specific images. The original file keeps its internal media query, so the `<img>` fallback still adapts anywhere that does work.

## Scope

Only the wordmark is affected. `readme-badges.svg` uses white text on coloured pills with no media query, so it reads correctly on both themes. The packaged npm README does not embed the wordmark.

## Verification

Both files parse as well-formed XML, with `readme-wordmark.svg` carrying both fills plus the query and `readme-wordmark-dark.svg` carrying only `#f0f6fc`.

I could not render these visually in this environment, so the check is structural rather than a screenshot. Worth a glance on your phone once merged.

```
node scripts/privacy-check.mjs --precommit   # passed, tarball still 11 files
python3 tests/test_basic.py                  # 30 passed, 0 failed
cd ts && npm test                            # 133 passed, 0 failed
```