### PR TITLE
Add Goose usage tracking and refresh model pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The versioning is [semver](https://semver.org); pre-1.0, minor versions may add 
 
 ## Unreleased
 
+### Added
+
+- Read Goose's local SQLite usage ledger with no setup, preserving per-call
+  model, token, cache, timestamp, and cost provenance while never querying the
+  messages table. Older sessions fall back to numeric accumulated totals only
+  when no ledger rows exist, preventing double counting. Fixture tested.
+
+### Pricing
+
+- Update DeepSeek V4 to the rates effective 2026-08-16 and select its published
+  peak/off-peak tier from each event's UTC timestamp.
+- Apply Gemini 3.6 Flash's introductory rate and add a dated CI guard for its
+  2027-01-01 change; restore Codestral from Mistral's current price list; add
+  Grok 4.6 and Z.AI's current GLM text models. Keep the Python SDK table and
+  time-tier calculation in sync with the JavaScript core.
+
 ## 0.6.0 — 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </h1>
 
 **Local-first usage and cost meter for Claude Code, Codex, Cursor, Grok Build,
-and other AI coding agents — no account, no telemetry.**
+Goose, and other AI coding agents — no account, no telemetry.**
 
 [Website](https://tokimeter.com) · [Coverage](#coverage-and-data-fidelity) ·
 [How the numbers work](#honest-numbers-by-design)
@@ -40,7 +40,7 @@ npx tokimeter install
 
 ## Why Tokimeter exists
 
-I use Claude Code, Codex, Cursor, Hermes, Grok Build, and sometimes more. Each
+I use Claude Code, Codex, Cursor, Goose, Hermes, Grok Build, and sometimes more. Each
 stores a different part of the usage picture. Tokimeter brings the numeric
 metadata already on your machine into one private report, so usage, limits,
 cache savings, and API-equivalent costs are easier to understand.
@@ -201,6 +201,7 @@ the report only observes.
 | Codex (CLI/Desktop) | Live verified | Local session logs shared by CLI and desktop coding sessions; no setup for reports, optional setup for live metering/overlay | Exact recorded token/cache counts and `~` cost. Vendor-reported 5h/weekly counters and resets when Codex records them. |
 | Cursor CLI/Desktop Agent | Live verified | Status-line and stop hooks after `tokimeter setup cursor`; CSV import for classic editor chat | Exact per-turn usage after hook setup, local windows, and user-budget warnings. Earlier hookless turns are not reconstructed. |
 | Grok Build | Live verified | Local `~/.grok/logs`; optional stop hook for alarms | Exact recorded per-turn tokens and `~` cost. Local windows and user budgets, not a claimed vendor quota. |
+| Goose | Fixture tested | Local `sessions.db` numeric usage ledger; no setup for reports | Per-call model/token/cache counts and provider-reported or estimated cost when recorded. Message content is never queried. |
 | Hermes | Live verified | Local `~/.hermes` database; no setup for reports | Provider-recorded session totals and billed cost when present; otherwise priced `~` estimates. |
 | OpenHuman | Fixture tested | Active workspace `state/costs.jsonl`; no setup for reports | Exact recorded token buckets. Costs are per-request model costs, not TinyHumans credit use or your subscription bill. Memory and transcript data are never read. |
 | opencode | Live verified with 1.17.18 | Local message files/database; no setup for reports | Recorded token counts and request-time cost when present; otherwise priced `~` estimates. |
@@ -235,6 +236,15 @@ subagents, and self-hosted Telegram bridging, and sessions are labeled by
 source in the report. (Only Nous's fully hosted bots leave no local data to
 read.) `--tool hermes` scopes to it; when Hermes reports its own billed cost,
 Tokimeter uses that instead of estimating.
+
+**Goose**: tracked automatically, zero setup, from Goose's local
+`sessions/sessions.db` database. Tokimeter reads the numeric `usage_ledger`
+for per-call model, input/output, cache, timestamp, and cost provenance; it
+never queries Goose's `messages` table. Migrated sessions that predate the
+ledger fall back to numeric accumulated session totals only when they have no
+ledger rows, avoiding double counting. `GOOSE_PATH_ROOT` is honored and
+`--tool goose` scopes any report to it. This reader is fixture tested, not yet
+claimed as live verified.
 
 **OpenHuman**: tracked automatically from the active workspace's append-only
 `state/costs.jsonl` ledger (normally under `~/.openhuman/users/<local-id>/workspace`;

--- a/docs/PRICES.md
+++ b/docs/PRICES.md
@@ -9,7 +9,7 @@ them to locally recorded token counts to produce an API-equivalent value, which
 it marks `~$` precisely because it is not a bill. See
 [the pricing methodology](PRICING.md) for how that distinction is enforced.
 
-62 models across 8 priced providers.
+78 models across 8 priced providers.
 7 of 8 are sourced and verified.
 
 > **1 providers below carry disputed rates.** Cursor were checked against their published pricing and did not match. Their sections say so, and their numbers should not be relied on until they are corrected. They are listed here rather than quietly omitted because hiding them would be the dishonest option.
@@ -17,7 +17,7 @@ it marks `~$` precisely because it is not a bill. See
 ## OpenAI
 
 **Source:** [developers.openai.com/api/docs/pricing](https://developers.openai.com/api/docs/pricing)  
-**Verified:** 2026-08-04
+**Verified:** 2026-08-21
 
 Standard (non-batch) text rates. o1-mini and gpt-4-turbo are no longer listed and keep their last published rates for older tracked usage.
 
@@ -46,7 +46,7 @@ Standard (non-batch) text rates. o1-mini and gpt-4-turbo are no longer listed an
 ## Anthropic
 
 **Source:** [platform.claude.com pricing](https://platform.claude.com/docs/en/about-claude/pricing)  
-**Verified:** 2026-08-04
+**Verified:** 2026-08-21
 
 Cache read is 0.1x input; cache write is the 5-minute-TTL rate at 1.25x input. Re-verified with no changes.
 
@@ -67,13 +67,13 @@ Cache read is 0.1x input; cache write is the 5-minute-TTL rate at 1.25x input. R
 ## Google
 
 **Source:** [ai.google.dev Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing)  
-**Verified:** 2026-08-04
+**Verified:** 2026-08-21
 
-Short-context (<=200k) text tier. Gemini prices audio input and >200k context higher; those tiers are not modeled, so such usage is under-valued rather than guessed.
+Short-context (<=200k) text tier. Gemini 3.6 Flash uses its introductory rate through 2026-12-31. Audio and >200k tiers are not modeled, so such usage is under-valued rather than guessed.
 
 | Model | Input | Cache read | Cache write | Output |
 |---|---|---|---|---|
-| `gemini-3.6-flash` | $1.50 | $0.15 | $1.875 (1.25× input) | $7.50 |
+| `gemini-3.6-flash` | $0.75 | $0.075 | $0.9375 (1.25× input) | $3.75 |
 | `gemini-3.5-flash` | $1.50 | $0.15 | $1.875 (1.25× input) | $9.00 |
 | `gemini-3.5-flash-lite` | $0.30 | $0.03 | $0.375 (1.25× input) | $2.50 |
 | `gemini-3.1-flash-lite` | $0.25 | $0.025 | $0.3125 (1.25× input) | $1.50 |
@@ -85,9 +85,9 @@ Short-context (<=200k) text tier. Gemini prices audio input and >200k context hi
 ## Mistral
 
 **Source:** [mistral.ai/pricing/api](https://mistral.ai/pricing/api/)  
-**Verified:** 2026-08-04
+**Verified:** 2026-08-21
 
-The floating -latest aliases are priced against the current generation they resolve to. Cache read is Mistral's published 90 percent discount.
+The floating -latest aliases are priced against the current generation they resolve to. Codestral is listed again at its current published rate. Cache read is Mistral's published 90 percent discount.
 
 | Model | Input | Cache read | Cache write | Output |
 |---|---|---|---|---|
@@ -97,17 +97,19 @@ The floating -latest aliases are priced against the current generation they reso
 | `ministral-3-3b` | $0.10 | $0.01 | $0.125 (1.25× input) | $0.10 |
 | `ministral-3-8b` | $0.15 | $0.015 | $0.1875 (1.25× input) | $0.15 |
 | `ministral-3-14b` | $0.20 | $0.02 | $0.25 (1.25× input) | $0.20 |
+| `codestral` | $0.30 | $0.03 | $0.375 (1.25× input) | $0.90 |
 
 ## xAI
 
 **Source:** [docs.x.ai models pricing](https://docs.x.ai/docs/models)  
-**Verified:** 2026-08-04
+**Verified:** 2026-08-21
 
-Rates use the <200k context tier; xAI charges double above it and that tier is not modeled. Models below grok-4.3 are no longer listed and keep their last published rates.
+Rates use the <200k context tier; xAI charges more above it and that tier is not modeled. Grok 4.6 was added from the current model page. Delisted models keep their last published rates for older usage.
 
 | Model | Input | Cache read | Cache write | Output |
 |---|---|---|---|---|
 | `grok-build` | $1.00 | $0.20 | $1.25 (1.25× input) | $2.00 |
+| `grok-4.6` | $2.00 | $0.50 | $2.50 (1.25× input) | $6.00 |
 | `grok-4.5` | $2.00 | $0.30 | $2.50 (1.25× input) | $6.00 |
 | `grok-4.3` | $1.25 | $0.20 | $1.5625 (1.25× input) | $2.50 |
 | `grok-composer-2.5-fast` | $3.00 | _not published_ | $3.75 (1.25× input) | $15.00 |
@@ -120,25 +122,39 @@ Rates use the <200k context tier; xAI charges double above it and that tier is n
 ## DeepSeek
 
 **Source:** [api-docs.deepseek.com pricing](https://api-docs.deepseek.com/quick_start/pricing)  
-**Verified:** 2026-08-04
+**Verified:** 2026-08-21
 
-Standard rates. Announced peak-hour pricing at 2x has no published effective date and is not modeled, so peak usage is under-valued rather than guessed.
+Off-peak and peak rates effective 2026-08-16. Tokimeter selects the published peak tier for 01:00-04:00 and 06:00-10:00 UTC from each event timestamp; all other hours use off-peak.
 
 | Model | Input | Cache read | Cache write | Output |
 |---|---|---|---|---|
-| `deepseek-v4-flash` | $0.14 | $0.0028 | $0.175 (1.25× input) | $0.28 |
-| `deepseek-v4-pro` | $0.435 | $0.0036 | $0.5437 (1.25× input) | $0.87 |
+| `deepseek-v4-flash` | $0.22 | $0.007 | $0.275 (1.25× input) | $0.66 |
+| `deepseek-v4-pro` | $0.66 | $0.022 | $0.825 (1.25× input) | $1.98 |
 
 ## Z.AI
 
 **Source:** [docs.z.ai pricing](https://docs.z.ai/guides/overview/pricing)  
-**Verified:** 2026-08-04
+**Verified:** 2026-08-21
 
-glm-5.2 verified. The other GLM entries are no longer listed and keep their last published rates for older tracked usage.
+Current text-model rates through GLM-5.3 are verified. Older GLM entries no longer listed keep their last published rates for historical usage.
 
 | Model | Input | Cache read | Cache write | Output |
 |---|---|---|---|---|
 | `glm-5.2` | $1.40 | $0.26 | $1.75 (1.25× input) | $4.40 |
+| `glm-5.3` | $1.40 | $0.26 | $1.75 (1.25× input) | $4.40 |
+| `glm-5.1` | $1.40 | $0.26 | $1.75 (1.25× input) | $4.40 |
+| `glm-5` | $1.00 | $0.20 | $1.25 (1.25× input) | $3.20 |
+| `glm-5-turbo` | $1.20 | $0.24 | $1.50 (1.25× input) | $4.00 |
+| `glm-4.7` | $0.60 | $0.11 | $0.75 (1.25× input) | $2.20 |
+| `glm-4.7-flashx` | $0.07 | $0.01 | $0.0875 (1.25× input) | $0.40 |
+| `glm-4.6` | $0.60 | $0.11 | $0.75 (1.25× input) | $2.20 |
+| `glm-4.5` | $0.60 | $0.11 | $0.75 (1.25× input) | $2.20 |
+| `glm-4.5-x` | $2.20 | $0.45 | $2.75 (1.25× input) | $8.90 |
+| `glm-4.5-air` | $0.20 | $0.03 | $0.25 (1.25× input) | $1.10 |
+| `glm-4.5-airx` | $1.10 | $0.22 | $1.375 (1.25× input) | $4.50 |
+| `glm-4-32b-0414-128k` | $0.10 | _not published_ | $0.125 (1.25× input) | $0.10 |
+| `glm-4.7-flash` | $0.00 | _not published_ | $0.00 (1.25× input) | $0.00 |
+| `glm-4.5-flash` | $0.00 | _not published_ | $0.00 (1.25× input) | $0.00 |
 | `glm-5-plus` | $0.70 | _not published_ | $0.875 (1.25× input) | $2.80 |
 | `glm-5-air` | $0.10 | _not published_ | $0.125 (1.25× input) | $0.40 |
 | `glm-5-flash` | $0.10 | _not published_ | $0.125 (1.25× input) | $0.10 |
@@ -178,6 +194,7 @@ cannot quietly go stale.
 | Model | Effective | Change |
 |---|---|---|
 | `claude-sonnet-5` | 2026-08-31 | Introductory $2 input / $10 output applies through 2026-08-31, then reverts to $3 / $15 with cache read $0.30 and 5-minute cache write $3.75. |
+| `gemini-3.6-flash` | 2027-01-01 | Introductory $0.75 input / $3.75 output applies through 2026-12-31, then changes to $1.50 / $7.50 with cache read $0.15. |
 
 ## How to read this
 
@@ -190,4 +207,4 @@ cannot quietly go stale.
 - Local overrides in `~/.tokimeter/pricing.json` and the opt-in community feed
   take precedence in that order and are not shown here.
 
-_Generated 2026-08-04 from `ts/packages/core/src/pricing.js`._
+_Generated 2026-08-20 from `ts/packages/core/src/pricing.js`._

--- a/docs/pricing-sources.json
+++ b/docs/pricing-sources.json
@@ -7,22 +7,22 @@
       "label": "OpenAI",
       "source": "developers.openai.com/api/docs/pricing",
       "url": "https://developers.openai.com/api/docs/pricing",
-      "verified": "2026-08-04",
+      "verified": "2026-08-21",
       "note": "Standard (non-batch) text rates. o1-mini and gpt-4-turbo are no longer listed and keep their last published rates for older tracked usage."
     },
     "anthropic": {
       "label": "Anthropic",
       "source": "platform.claude.com pricing",
       "url": "https://platform.claude.com/docs/en/about-claude/pricing",
-      "verified": "2026-08-04",
+      "verified": "2026-08-21",
       "note": "Cache read is 0.1x input; cache write is the 5-minute-TTL rate at 1.25x input. Re-verified with no changes."
     },
     "xai": {
       "label": "xAI",
       "source": "docs.x.ai models pricing",
       "url": "https://docs.x.ai/docs/models",
-      "verified": "2026-08-04",
-      "note": "Rates use the <200k context tier; xAI charges double above it and that tier is not modeled. Models below grok-4.3 are no longer listed and keep their last published rates."
+      "verified": "2026-08-21",
+      "note": "Rates use the <200k context tier; xAI charges more above it and that tier is not modeled. Grok 4.6 was added from the current model page. Delisted models keep their last published rates for older usage."
     },
     "cursor": {
       "label": "Cursor",
@@ -39,22 +39,22 @@
       "label": "Z.AI",
       "source": "docs.z.ai pricing",
       "url": "https://docs.z.ai/guides/overview/pricing",
-      "verified": "2026-08-04",
-      "note": "glm-5.2 verified. The other GLM entries are no longer listed and keep their last published rates for older tracked usage."
+      "verified": "2026-08-21",
+      "note": "Current text-model rates through GLM-5.3 are verified. Older GLM entries no longer listed keep their last published rates for historical usage."
     },
     "google": {
       "label": "Google",
       "source": "ai.google.dev Gemini API pricing",
       "url": "https://ai.google.dev/gemini-api/docs/pricing",
-      "verified": "2026-08-04",
-      "note": "Short-context (<=200k) text tier. Gemini prices audio input and >200k context higher; those tiers are not modeled, so such usage is under-valued rather than guessed."
+      "verified": "2026-08-21",
+      "note": "Short-context (<=200k) text tier. Gemini 3.6 Flash uses its introductory rate through 2026-12-31. Audio and >200k tiers are not modeled, so such usage is under-valued rather than guessed."
     },
     "mistral": {
       "label": "Mistral",
       "source": "mistral.ai/pricing/api",
       "url": "https://mistral.ai/pricing/api/",
-      "verified": "2026-08-04",
-      "note": "The floating -latest aliases are priced against the current generation they resolve to. Cache read is Mistral's published 90 percent discount."
+      "verified": "2026-08-21",
+      "note": "The floating -latest aliases are priced against the current generation they resolve to. Codestral is listed again at its current published rate. Cache read is Mistral's published 90 percent discount."
     },
     "meta": {
       "label": "Meta",
@@ -67,8 +67,8 @@
       "label": "DeepSeek",
       "source": "api-docs.deepseek.com pricing",
       "url": "https://api-docs.deepseek.com/quick_start/pricing",
-      "verified": "2026-08-04",
-      "note": "Standard rates. Announced peak-hour pricing at 2x has no published effective date and is not modeled, so peak usage is under-valued rather than guessed."
+      "verified": "2026-08-21",
+      "note": "Off-peak and peak rates effective 2026-08-16. Tokimeter selects the published peak tier for 01:00-04:00 and 06:00-10:00 UTC from each event timestamp; all other hours use off-peak."
     }
   },
   "scheduledChanges": [
@@ -81,6 +81,16 @@
         "output": 15.0,
         "cached": 0.3,
         "cacheWrite": 3.75
+      }
+    },
+    {
+      "model": "gemini-3.6-flash",
+      "effective": "2027-01-01",
+      "note": "Introductory $0.75 input / $3.75 output applies through 2026-12-31, then changes to $1.50 / $7.50 with cache read $0.15.",
+      "expectedAfter": {
+        "input": 1.5,
+        "output": 7.5,
+        "cached": 0.15
       }
     }
   ]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -117,6 +117,33 @@ def test_pricing_current_recorded_models():
     print("✓ test_pricing_current_recorded_models passed")
 
 
+def test_pricing_dated_and_inclusive_cache_rates():
+    """Time-tiered rates and inclusive ledgers match the JavaScript pricer."""
+    pricer = Pricer()
+    off_peak = pricer.price_call(
+        "deepseek-v4-flash", 1_000_000, 1_000_000,
+        timestamp=1787313600,  # 2026-08-21 12:00 UTC
+    )
+    peak = pricer.price_call(
+        "deepseek-v4-flash", 1_000_000, 1_000_000,
+        timestamp=1787293800,  # 2026-08-21 06:30 UTC
+    )
+    assert off_peak[2] == 0.88
+    assert peak[2] == 1.76
+
+    inclusive = pricer.price_call(
+        "claude-sonnet-5", 1_000_000, 0,
+        cached_tokens=200_000,
+        cache_creation_tokens=100_000,
+        cache_creation_included_in_input=True,
+    )
+    assert inclusive[2] == 1.69
+    assert pricer.get_price("codestral-latest").model == "codestral"
+    assert pricer.get_price("grok-4.6").cached_input_per_1m == 0.5
+    assert pricer.get_price("glm-5.3").output_per_1m == 4.4
+    print("✓ test_pricing_dated_and_inclusive_cache_rates passed")
+
+
 def test_tracker_memory():
     """Test in-memory tracking."""
     tracker = Tracker()  # in-memory mode
@@ -1041,6 +1068,7 @@ def run_all():
         test_pricing_unknown_model,
         test_pricing_aliases,
         test_pricing_current_recorded_models,
+        test_pricing_dated_and_inclusive_cache_rates,
         test_tracker_memory,
         test_tracker_separates_unknown_pricing,
         test_tracker_sqlite,

--- a/tokimeter/pricing.py
+++ b/tokimeter/pricing.py
@@ -8,6 +8,7 @@ Prices are USD per 1,000,000 tokens.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 
 @dataclass
@@ -20,16 +21,20 @@ class ModelPrice:
     cached_input_per_1m: float = 0.0   # cache-read input price
     aliases: tuple = ()  # alternative names that map to this model
     cache_write_per_1m: float = 0.0    # cache-write/creation input price (0 = default 1.25x input)
+    peak_utc_hours: tuple = ()         # half-open UTC hour ranges, e.g. ((1, 4), (6, 10))
+    peak_input_per_1m: float = 0.0
+    peak_output_per_1m: float = 0.0
+    peak_cached_input_per_1m: float = 0.0
 
 
 # ─── OpenAI ─────────────────────────────────────────────────────────────────
 
 OPENAI_PRICES = [
-    # Verified against developers.openai.com/api/docs/pricing, 2026-08-04.
+    # Verified against developers.openai.com/api/docs/pricing, 2026-08-21.
     # 5.6+ publishes explicit cache-write pricing at 1.25x input. o1-mini is no
     # longer listed and keeps its last published rate for older usage.
     ModelPrice("openai", "gpt-5.6-sol",       5.00,  30.00, 0.50,  (), 6.25),
-    ModelPrice("openai", "gpt-5.6-terra",     2.00,  12.00, 0.20,  (), 3.125),
+    ModelPrice("openai", "gpt-5.6-terra",     2.00,  12.00, 0.20,  (), 2.50),
     ModelPrice("openai", "gpt-5.6-luna",      0.20,   1.20, 0.02,  (), 0.25),
     ModelPrice("openai", "gpt-5.5",           5.00,  30.00, 0.50),
     ModelPrice("openai", "gpt-5.4",           2.50,  15.00, 0.25),
@@ -54,7 +59,7 @@ OPENAI_PRICES = [
 # ─── Anthropic ──────────────────────────────────────────────────────────────
 
 ANTHROPIC_PRICES = [
-    # Verified against platform.claude.com pricing, 2026-08-04.
+    # Verified against platform.claude.com pricing, 2026-08-21.
     # cached = cache-read (~0.1x input); cache_write = 5-min-TTL cache-write (~1.25x input).
     ModelPrice("anthropic", "claude-fable-5",          10.00, 50.00, 1.00,
                ("claude-mythos-5",), 12.50),
@@ -85,12 +90,12 @@ ANTHROPIC_PRICES = [
 
 # ─── Google Gemini ──────────────────────────────────────────────────────────
 
-# Verified against ai.google.dev/gemini-api/docs/pricing, 2026-08-04, at the
+# Verified against ai.google.dev/gemini-api/docs/pricing, 2026-08-21, at the
 # short-context (<=200k) text tier. Gemini prices audio input and >200k context
 # higher; those tiers are not modeled, so such usage is under-valued rather
 # than guessed.
 GOOGLE_PRICES = [
-    ModelPrice("google", "gemini-3.6-flash",        1.50,  7.50,  0.15),
+    ModelPrice("google", "gemini-3.6-flash",        0.75,  3.75,  0.075),
     ModelPrice("google", "gemini-3.5-flash",        1.50,  9.00,  0.15,
                ("gemini-3-flash",)),
     ModelPrice("google", "gemini-3.5-flash-lite",   0.30,  2.50,  0.03,
@@ -107,7 +112,7 @@ GOOGLE_PRICES = [
 
 # ─── Mistral ────────────────────────────────────────────────────────────────
 
-# Verified against mistral.ai/pricing/api, 2026-08-04. The floating -latest
+# Verified against mistral.ai/pricing/api, 2026-08-21. The floating -latest
 # aliases resolve to the current generation. Cache read is a 90% discount.
 MISTRAL_PRICES = [
     ModelPrice("mistral", "mistral-large-3",        0.50, 1.50, 0.05,
@@ -119,7 +124,9 @@ MISTRAL_PRICES = [
     ModelPrice("mistral", "ministral-3-3b",         0.10, 0.10, 0.01),
     ModelPrice("mistral", "ministral-3-8b",         0.15, 0.15, 0.015),
     ModelPrice("mistral", "ministral-3-14b",        0.20, 0.20, 0.02),
-    ModelPrice("mistral", "mistral-embed",          0.12, 0.0),
+    ModelPrice("mistral", "codestral",              0.30, 0.90, 0.03,
+               ("codestral-latest",)),
+    ModelPrice("mistral", "mistral-embed",          0.10, 0.0),
 ]
 
 # ─── Meta Llama (via Together / Groq / Replicate) ──────────────────────────
@@ -134,9 +141,13 @@ LLAMA_PRICES = []
 # ─── xAI Grok ───────────────────────────────────────────────────────────────
 
 XAI_PRICES = [
-    # Verified against docs.x.ai models pricing, 2026-08-04, at the <200k tier.
-    # Models below grok-4.5 are no longer listed and keep last published rates.
+    # Verified against docs.x.ai models pricing, 2026-08-21, at the <200k tier.
+    # Delisted models keep their last published rates for older usage.
+    ModelPrice("xai", "grok-build",        1.00,  2.00, 0.20,
+               ("grok-build-0.1", "grok-build-b")),
+    ModelPrice("xai", "grok-4.6",          2.00,  6.00, 0.50, ("grok-4.6-latest",)),
     ModelPrice("xai", "grok-4.5",          2.00,  6.00, 0.30, ("grok-4.5-latest",)),
+    ModelPrice("xai", "grok-4.3",          1.25,  2.50, 0.20),
     ModelPrice("xai", "grok-4",            5.00, 15.00),
     ModelPrice("xai", "grok-4-fast",       0.20, 0.50),
     ModelPrice("xai", "grok-3",            3.00, 15.00),
@@ -146,12 +157,15 @@ XAI_PRICES = [
 
 # ─── DeepSeek ───────────────────────────────────────────────────────────────
 
-# Verified against api-docs.deepseek.com/quick_start/pricing, 2026-08-04.
-# Announced peak-hour pricing at 2x standard rates has no effective date yet
-# and is not modeled, so peak usage is under-valued rather than guessed.
+# Verified against api-docs.deepseek.com/quick_start/pricing, 2026-08-21.
+# Base fields are off-peak; Pricer selects the published peak tier from time.
 DEEPSEEK_PRICES = [
-    ModelPrice("deepseek", "deepseek-v4-flash",    0.14,  0.28, 0.0028),
-    ModelPrice("deepseek", "deepseek-v4-pro",      0.435, 0.87, 0.003625),
+    ModelPrice("deepseek", "deepseek-v4-flash", 0.22, 0.66, 0.007,
+               peak_utc_hours=((1, 4), (6, 10)), peak_input_per_1m=0.44,
+               peak_output_per_1m=1.32, peak_cached_input_per_1m=0.014),
+    ModelPrice("deepseek", "deepseek-v4-pro", 0.66, 1.98, 0.022,
+               peak_utc_hours=((1, 4), (6, 10)), peak_input_per_1m=1.32,
+               peak_output_per_1m=3.96, peak_cached_input_per_1m=0.044),
 ]
 
 # ─── Cohere ─────────────────────────────────────────────────────────────────
@@ -165,6 +179,21 @@ COHERE_PRICES = [
 # ─── Z.AI (GLM/Zhipu) ──────────────────────────────────────────────────────
 
 ZAI_PRICES = [
+    ModelPrice("zai", "glm-5.3",       1.40, 4.40, 0.26),
+    ModelPrice("zai", "glm-5.2",       1.40, 4.40, 0.26),
+    ModelPrice("zai", "glm-5.1",       1.40, 4.40, 0.26),
+    ModelPrice("zai", "glm-5",         1.00, 3.20, 0.20),
+    ModelPrice("zai", "glm-5-turbo",   1.20, 4.00, 0.24),
+    ModelPrice("zai", "glm-4.7",       0.60, 2.20, 0.11),
+    ModelPrice("zai", "glm-4.7-flashx", 0.07, 0.40, 0.01),
+    ModelPrice("zai", "glm-4.6",       0.60, 2.20, 0.11),
+    ModelPrice("zai", "glm-4.5",       0.60, 2.20, 0.11),
+    ModelPrice("zai", "glm-4.5-x",     2.20, 8.90, 0.45),
+    ModelPrice("zai", "glm-4.5-air",   0.20, 1.10, 0.03),
+    ModelPrice("zai", "glm-4.5-airx",  1.10, 4.50, 0.22),
+    ModelPrice("zai", "glm-4-32b-0414-128k", 0.10, 0.10),
+    ModelPrice("zai", "glm-4.7-flash", 0.00, 0.00),
+    ModelPrice("zai", "glm-4.5-flash", 0.00, 0.00),
     ModelPrice("zai", "glm-5-plus",    0.70, 2.80),
     ModelPrice("zai", "glm-5-air",     0.10, 0.40),
     ModelPrice("zai", "glm-5-flash",   0.10, 0.10),
@@ -230,6 +259,8 @@ class Pricer:
         provider: str = "",
         cache_creation_tokens: int = 0,
         cached_included_in_input: bool = True,
+        cache_creation_included_in_input: bool = False,
+        timestamp: float | None = None,
     ) -> tuple[float, float, float]:
         """
         Returns (input_cost, output_cost, total_cost) in USD.
@@ -245,23 +276,40 @@ class Pricer:
             # through rough_estimate_call(), never in authoritative totals.
             return (0.0, 0.0, 0.0)
 
-        # Non-cached input tokens billed at full rate
-        billable_input = max(0, input_tokens - cached_tokens) if cached_included_in_input else input_tokens
-        in_cost = (billable_input / 1_000_000) * price.input_per_1m
+        input_rate = price.input_per_1m
+        output_rate = price.output_per_1m
+        cached_rate = price.cached_input_per_1m
+        if price.peak_utc_hours:
+            raw_timestamp = timestamp
+            if raw_timestamp is None:
+                now = datetime.now(timezone.utc)
+            else:
+                seconds = raw_timestamp / 1000 if raw_timestamp > 100_000_000_000 else raw_timestamp
+                now = datetime.fromtimestamp(seconds, timezone.utc)
+            if any(start <= now.hour < end for start, end in price.peak_utc_hours):
+                input_rate = price.peak_input_per_1m
+                output_rate = price.peak_output_per_1m
+                cached_rate = price.peak_cached_input_per_1m
+
+        included_cache = (cached_tokens if cached_included_in_input else 0)
+        if cache_creation_included_in_input:
+            included_cache += cache_creation_tokens
+        billable_input = max(0, input_tokens - included_cache)
+        in_cost = (billable_input / 1_000_000) * input_rate
 
         # Cache-read tokens at discount rate
-        if cached_tokens > 0 and price.cached_input_per_1m > 0:
-            in_cost += (cached_tokens / 1_000_000) * price.cached_input_per_1m
+        if cached_tokens > 0 and cached_rate > 0:
+            in_cost += (cached_tokens / 1_000_000) * cached_rate
         elif cached_tokens > 0:
             # If no explicit cached price, assume 50% discount
-            in_cost += (cached_tokens / 1_000_000) * price.input_per_1m * 0.5
+            in_cost += (cached_tokens / 1_000_000) * input_rate * 0.5
 
         # Cache-write tokens at a premium (Anthropic 5-min TTL is 1.25x input)
         if cache_creation_tokens > 0:
-            write_rate = price.cache_write_per_1m or price.input_per_1m * 1.25
+            write_rate = price.cache_write_per_1m or input_rate * 1.25
             in_cost += (cache_creation_tokens / 1_000_000) * write_rate
 
-        out_cost = (output_tokens / 1_000_000) * price.output_per_1m
+        out_cost = (output_tokens / 1_000_000) * output_rate
 
         return (
             round(in_cost, 6),

--- a/ts/packages/core/src/pricing.js
+++ b/ts/packages/core/src/pricing.js
@@ -22,6 +22,7 @@ import { dirname, join } from 'node:path';
  * @property {string[]} aliases  - alternative names that map to this model
  * @property {boolean} [custom] - user-supplied local price
  * @property {boolean} [feed] - community-feed price
+ * @property {{ peakUtcHours: number[][], peak: { input: number, output: number, cached: number } }} [timeRates]
  */
 
 // ─── Prices ─────────────────────────────────────────────────────────────────
@@ -29,7 +30,7 @@ import { dirname, join } from 'node:path';
 /** @type {ModelPrice[]} */
 const PRICES = [
   // ─── OpenAI ───────────────────────────────────────────────────────────────
-  // Verified against developers.openai.com/api/docs/pricing, 2026-08-04.
+  // Verified against developers.openai.com/api/docs/pricing, 2026-08-21.
   // 5.6+ publishes explicit cache-write pricing at 1.25x input. o1-mini is no
   // longer listed and is kept at its last published rate for older usage.
   { provider: "openai", model: "gpt-5.6-sol",       input: 5.00,  output: 30.00, cached: 0.50,  cacheWrite: 6.25 },
@@ -55,7 +56,7 @@ const PRICES = [
   { provider: "openai", model: "gpt-3.5-turbo",    input: 0.50,  output: 1.50,  cached: 0 },
 
   // ─── Anthropic ────────────────────────────────────────────────────────────
-  // Verified against platform.claude.com pricing, 2026-08-04.
+  // Verified against platform.claude.com pricing, 2026-08-21.
   // cached = cache-read rate (~0.1x input); cacheWrite = 5-minute-TTL cache-write rate (~1.25x input).
   { provider: "anthropic", model: "claude-fable-5",          input: 10.00, output: 50.00, cached: 1.00, cacheWrite: 12.50,
     aliases: ["claude-mythos-5"] },
@@ -80,12 +81,14 @@ const PRICES = [
   { provider: "anthropic", model: "claude-3-haiku",          input: 0.25,  output: 1.25,  cached: 0 },
 
   // ─── Google Gemini ────────────────────────────────────────────────────────
-  // Verified against ai.google.dev/gemini-api/docs/pricing, 2026-08-04, at the
+  // Verified against ai.google.dev/gemini-api/docs/pricing, 2026-08-21, at the
   // short-context (<=200k) text tier, matching the convention used for OpenAI
   // above. Gemini prices audio input and >200k context higher; Tokimeter does
   // not model those tiers, so long-context and audio usage is under-valued
   // rather than guessed.
-  { provider: "google", model: "gemini-3.6-flash",        input: 1.50,  output: 7.50,  cached: 0.15 },
+  // Introductory rates apply through 2026-12-31; a dated CI guard prevents
+  // them from silently surviving the change to $1.50/$7.50 on 2027-01-01.
+  { provider: "google", model: "gemini-3.6-flash",        input: 0.75,  output: 3.75,  cached: 0.075 },
   { provider: "google", model: "gemini-3.5-flash",        input: 1.50,  output: 9.00,  cached: 0.15,
     aliases: ["gemini-3-flash"] },
   { provider: "google", model: "gemini-3.5-flash-lite",   input: 0.30,  output: 2.50,  cached: 0.03,
@@ -98,7 +101,7 @@ const PRICES = [
   { provider: "google", model: "gemini-2.5-flash-lite",   input: 0.10,  output: 0.40,  cached: 0.01 },
 
   // ─── Mistral ──────────────────────────────────────────────────────────────
-  // Verified against mistral.ai/pricing/api, 2026-08-04. The floating -latest
+  // Verified against mistral.ai/pricing/api, 2026-08-21. The floating -latest
   // aliases resolve to the current generation, so they are priced against it.
   // Mistral publishes cache-read at a 90% discount on input.
   { provider: "mistral", model: "mistral-large-3",        input: 0.50, output: 1.50, cached: 0.05,
@@ -110,6 +113,8 @@ const PRICES = [
   { provider: "mistral", model: "ministral-3-3b",         input: 0.10, output: 0.10, cached: 0.01 },
   { provider: "mistral", model: "ministral-3-8b",         input: 0.15, output: 0.15, cached: 0.015 },
   { provider: "mistral", model: "ministral-3-14b",        input: 0.20, output: 0.20, cached: 0.02 },
+  { provider: "mistral", model: "codestral",              input: 0.30, output: 0.90, cached: 0.03,
+    aliases: ["codestral-latest"] },
 
   // ─── Meta Llama ───────────────────────────────────────────────────────────
   // Intentionally unpriced. Meta publishes no generally available first-party
@@ -122,7 +127,7 @@ const PRICES = [
   //   tokimeter pricing set llama-4-maverick --input <in> --output <out>
 
   // ─── xAI Grok ─────────────────────────────────────────────────────────────
-  // Verified against docs.x.ai models pricing, 2026-08-04, at the <200k tier.
+  // Verified against docs.x.ai models pricing, 2026-08-21, at the <200k tier.
   // xAI publishes explicit cache-read rates; they were previously recorded as
   // unpriced. Models below grok-4.3 are no longer listed and keep their last
   // published rates for older tracked usage.
@@ -131,6 +136,8 @@ const PRICES = [
   // grok-build-0.1. No cached-input price published → cached tokens free.
   { provider: "xai", model: "grok-build",        input: 1.00, output: 2.00,  cached: 0.20,
     aliases: ["grok-build-0.1", "grok-build-b"] },
+  { provider: "xai", model: "grok-4.6",          input: 2.00, output: 6.00,  cached: 0.50,
+    aliases: ["grok-4.6-latest"] },
   // grok-4.5: docs.x.ai flagship (verified 2026-07-11); $2/$6, 500k context,
   // no cached-input price published → cached tokens free.
   { provider: "xai", model: "grok-4.5",          input: 2.00, output: 6.00,  cached: 0.30,
@@ -149,13 +156,13 @@ const PRICES = [
   { provider: "xai", model: "grok-2",            input: 2.00, output: 10.00, cached: 0 },
 
   // ─── DeepSeek ─────────────────────────────────────────────────────────────
-  // Verified against api-docs.deepseek.com/quick_start/pricing, 2026-08-04.
-  // DeepSeek has announced peak-hour pricing at 2x standard rates (09:00-12:00
-  // and 14:00-18:00 UTC+8) with no effective date published yet. Tokimeter
-  // prices the standard rate and does not model the peak multiplier, so peak
-  // usage is under-valued rather than guessed.
-  { provider: "deepseek", model: "deepseek-v4-flash",    input: 0.14,  output: 0.28, cached: 0.0028 },
-  { provider: "deepseek", model: "deepseek-v4-pro",      input: 0.435, output: 0.87, cached: 0.003625 },
+  // Verified against api-docs.deepseek.com/quick_start/pricing, 2026-08-21.
+  // Base fields are off-peak. priceCall selects the published 2x peak tier
+  // for calls from 01:00-04:00 and 06:00-10:00 UTC using the event timestamp.
+  { provider: "deepseek", model: "deepseek-v4-flash", input: 0.22, output: 0.66, cached: 0.007,
+    timeRates: { peakUtcHours: [[1, 4], [6, 10]], peak: { input: 0.44, output: 1.32, cached: 0.014 } } },
+  { provider: "deepseek", model: "deepseek-v4-pro", input: 0.66, output: 1.98, cached: 0.022,
+    timeRates: { peakUtcHours: [[1, 4], [6, 10]], peak: { input: 1.32, output: 3.96, cached: 0.044 } } },
 
   // ─── Cursor ───────────────────────────────────────────────────────────────
   // Composer 2.5 standard tier per cursor.com/docs/models-and-pricing
@@ -164,10 +171,24 @@ const PRICES = [
   { provider: "cursor", model: "composer-2.5", input: 0.50, output: 2.50, cached: 0.20 },
 
   // ─── Z.AI (GLM) ───────────────────────────────────────────────────────────
-  // glm-5.2: docs.z.ai pricing $1.40 in / $0.26 cached / $4.40 out
-  // (verified 2026-07-08). Cursor pricing docs list Composer 2.5 standard
+  // Current text-model rates verified against docs.z.ai pricing, 2026-08-21.
+  // Cursor pricing docs list Composer 2.5 standard
   // separately; see the xai block for the fast tier used by Grok Build.
   { provider: "zai", model: "glm-5.2",       input: 1.40, output: 4.40, cached: 0.26 },
+  { provider: "zai", model: "glm-5.3",       input: 1.40, output: 4.40, cached: 0.26 },
+  { provider: "zai", model: "glm-5.1",       input: 1.40, output: 4.40, cached: 0.26 },
+  { provider: "zai", model: "glm-5",         input: 1.00, output: 3.20, cached: 0.20 },
+  { provider: "zai", model: "glm-5-turbo",   input: 1.20, output: 4.00, cached: 0.24 },
+  { provider: "zai", model: "glm-4.7",       input: 0.60, output: 2.20, cached: 0.11 },
+  { provider: "zai", model: "glm-4.7-flashx", input: 0.07, output: 0.40, cached: 0.01 },
+  { provider: "zai", model: "glm-4.6",       input: 0.60, output: 2.20, cached: 0.11 },
+  { provider: "zai", model: "glm-4.5",       input: 0.60, output: 2.20, cached: 0.11 },
+  { provider: "zai", model: "glm-4.5-x",     input: 2.20, output: 8.90, cached: 0.45 },
+  { provider: "zai", model: "glm-4.5-air",   input: 0.20, output: 1.10, cached: 0.03 },
+  { provider: "zai", model: "glm-4.5-airx",  input: 1.10, output: 4.50, cached: 0.22 },
+  { provider: "zai", model: "glm-4-32b-0414-128k", input: 0.10, output: 0.10, cached: 0 },
+  { provider: "zai", model: "glm-4.7-flash", input: 0, output: 0, cached: 0 },
+  { provider: "zai", model: "glm-4.5-flash", input: 0, output: 0, cached: 0 },
   { provider: "zai", model: "glm-5-plus",    input: 0.70, output: 2.80, cached: 0 },
   { provider: "zai", model: "glm-5-air",     input: 0.10, output: 0.40, cached: 0 },
   { provider: "zai", model: "glm-5-flash",   input: 0.10, output: 0.10, cached: 0 },
@@ -246,8 +267,9 @@ const DOWNGRADES = {
  * @param {number} outputTokens
  * @param {number} cachedTokens - cache-read tokens
  * @param {number} cacheCreationTokens - cache-write tokens (Anthropic reports these separately)
- * @param {{ cachedIncludedInInput?: boolean }} [options] - OpenAI/Google report inputTokens inclusive of
- *   cached tokens; Anthropic reports input/cache-read/cache-write as disjoint buckets.
+ * @param {{ cachedIncludedInInput?: boolean, cacheCreationIncludedInInput?: boolean, timestamp?: number }} [options]
+ *   Some ledgers report cache buckets as subsets of inputTokens. timestamp is
+ *   used for providers such as DeepSeek whose published rate varies by UTC hour.
  * @returns {{
  *   inputCost: number,
  *   outputCost: number,
@@ -258,14 +280,19 @@ const DOWNGRADES = {
  *   authoritative: boolean
  * }}
  */
-export function priceCall(model, inputTokens = 0, outputTokens = 0, cachedTokens = 0, cacheCreationTokens = 0, { cachedIncludedInInput = true } = {}) {
-  const price = lookupPrice(model);
+export function priceCall(model, inputTokens = 0, outputTokens = 0, cachedTokens = 0, cacheCreationTokens = 0, {
+  cachedIncludedInInput = true,
+  cacheCreationIncludedInInput = false,
+  timestamp = Date.now(),
+} = {}) {
+  const basePrice = lookupPrice(model);
 
-  if (!price) {
+  if (!basePrice) {
     // Unknown models are deliberately unpriced in authoritative totals. Keep
     // the old $2/$8 heuristic only as an explicitly separate rough estimate.
     const internal = knownInternalUnpriced(model);
-    const inCost = ((inputTokens + cacheCreationTokens) / 1_000_000) * 2.0;
+    const roughInput = inputTokens + (cacheCreationIncludedInInput ? 0 : cacheCreationTokens);
+    const inCost = (roughInput / 1_000_000) * 2.0;
     const outCost = (outputTokens / 1_000_000) * 8.0;
     return {
       inputCost: 0,
@@ -278,7 +305,10 @@ export function priceCall(model, inputTokens = 0, outputTokens = 0, cachedTokens
     };
   }
 
-  const billableInput = cachedIncludedInInput ? Math.max(0, inputTokens - cachedTokens) : inputTokens;
+  const price = priceForTimestamp(basePrice, timestamp);
+  const includedCache = (cachedIncludedInInput ? cachedTokens : 0)
+    + (cacheCreationIncludedInInput ? cacheCreationTokens : 0);
+  const billableInput = Math.max(0, inputTokens - includedCache);
   let inCost = (billableInput / 1_000_000) * price.input;
 
   if (cachedTokens > 0 && price.cached > 0) {
@@ -303,6 +333,16 @@ export function priceCall(model, inputTokens = 0, outputTokens = 0, cachedTokens
     pricingSource: price.custom ? 'custom' : (price.feed ? 'community' : 'verified'),
     authoritative: true,
   };
+}
+
+function priceForTimestamp(price, timestamp) {
+  const timeRates = price.timeRates;
+  if (!timeRates?.peak || !Array.isArray(timeRates.peakUtcHours)) return price;
+  const date = new Date(Number(timestamp));
+  if (Number.isNaN(date.getTime())) return price;
+  const hour = date.getUTCHours();
+  const peak = timeRates.peakUtcHours.some(([start, end]) => hour >= start && hour < end);
+  return peak ? { ...price, ...timeRates.peak, pricingTier: 'peak' } : price;
 }
 
 /**
@@ -507,6 +547,20 @@ function mergePrices(builtIn, custom) {
 
 function normalizePrice(price) {
   if (!price || !price.model) return null;
+  const peak = price.timeRates?.peak;
+  const peakUtcHours = price.timeRates?.peakUtcHours;
+  const timeRates = peak && Array.isArray(peakUtcHours)
+    ? {
+        peakUtcHours: peakUtcHours
+          .filter((range) => Array.isArray(range) && range.length === 2)
+          .map(([start, end]) => [Number(start), Number(end)]),
+        peak: {
+          input: Number(peak.input) || 0,
+          output: Number(peak.output) || 0,
+          cached: Number(peak.cached) || 0,
+        },
+      }
+    : undefined;
   return {
     provider: String(price.provider || 'custom'),
     model: String(price.model),
@@ -517,6 +571,7 @@ function normalizePrice(price) {
     aliases: Array.isArray(price.aliases) ? price.aliases.map(String) : [],
     custom: Boolean(price.custom),
     feed: Boolean(price.feed),
+    ...(timeRates ? { timeRates } : {}),
   };
 }
 

--- a/ts/packages/proxy/README.md
+++ b/ts/packages/proxy/README.md
@@ -59,7 +59,7 @@ your device.
 Live-verified readers in this release: Claude Code CLI/Desktop, Codex
 CLI/Desktop, Cursor CLI/Desktop Agent, Grok Build, Hermes, opencode 1.17.18,
 and Cline CLI 3.0.39.
-OpenHuman, GitHub Copilot CLI, and Aider are fixture-tested but were not
+Goose, OpenHuman, GitHub Copilot CLI, and Aider are fixture-tested but were not
 completed as live requests during release testing. Paid
 Anthropic/OpenAI/Venice API routes are experimental and test-covered but were
 not exercised against paid APIs or reconciled with provider invoices.

--- a/ts/packages/proxy/src/cli.js
+++ b/ts/packages/proxy/src/cli.js
@@ -26,9 +26,9 @@ import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { appendFileSync, chmodSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, readlinkSync, realpathSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
-import { basename, dirname, join, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import http from 'node:http';
-import { readClaudeUsageEvents, readClaudeAgentActivity, readCodexTokenEvents, readAiderHistoryEvents, readGrokUsageEvents, readGrokSessionMeta, analyzeLogFileFormat, readCodexRateLimitSnapshots, classifyCodexRateLimitWindows, buildHermesSessionQuery, hermesRowsToEvents, buildDelegationReport, buildAgentBreakdown, buildOrchestrationReport, buildBurnReport, buildBurnPlanner, buildSavingsReport, buildRoutingPolicy, formatRoutingPolicy, renderReportMarkdown, renderReportHtml, buildSessionTrace, buildMonthCard, renderMonthCardSvg, readOpencodeMessageFile, opencodeRowsToEvents, readClineTaskEvents, readClineSessionEvents, readCopilotOtelEvents, cursorStopPayloadToRecord, readCursorUsageEvents, parseCursorUsageCsv, readOpenHumanCostEvents, openHumanWorkspaceCandidates, recentCodexRolloutFiles as recentCodexRolloutFilesShared } from './parsers.js';
+import { readClaudeUsageEvents, readClaudeAgentActivity, readCodexTokenEvents, readAiderHistoryEvents, readGrokUsageEvents, readGrokSessionMeta, analyzeLogFileFormat, readCodexRateLimitSnapshots, classifyCodexRateLimitWindows, buildHermesSessionQuery, hermesRowsToEvents, buildGooseUsageQuery, gooseRowsToEvents, buildDelegationReport, buildAgentBreakdown, buildOrchestrationReport, buildBurnReport, buildBurnPlanner, buildSavingsReport, buildRoutingPolicy, formatRoutingPolicy, renderReportMarkdown, renderReportHtml, buildSessionTrace, buildMonthCard, renderMonthCardSvg, readOpencodeMessageFile, opencodeRowsToEvents, readClineTaskEvents, readClineSessionEvents, readCopilotOtelEvents, cursorStopPayloadToRecord, readCursorUsageEvents, parseCursorUsageCsv, readOpenHumanCostEvents, openHumanWorkspaceCandidates, recentCodexRolloutFiles as recentCodexRolloutFilesShared } from './parsers.js';
 import {
   chunkCloudEvents,
   clearCloudPause,
@@ -2804,6 +2804,14 @@ async function runDoctor() {
       : `${HERMES_STATE_DB} exists but no non-zero usage sessions were recognized`);
   }
 
+  const gooseDbs = gooseDatabaseCandidates().filter((path) => existsSync(path));
+  if (gooseDbs.length) {
+    const gooseEvents = readGooseUsageEvents({ sinceMs: Date.now() - 30 * 86400 * 1000 });
+    printDoctorLine('Goose reader', gooseEvents.length > 0, gooseEvents.length > 0
+      ? `${gooseEvents.length} recent usage event${gooseEvents.length === 1 ? '' : 's'} recognized from ${gooseDbs[0]}`
+      : `${gooseDbs[0]} exists but no non-zero numeric usage was recognized`);
+  }
+
   if (summary) {
     console.log(`  Spend summary       ${summary.todayCalls || 0} calls today / $${(summary.todayCost || 0).toFixed(4)}`);
   }
@@ -4067,6 +4075,63 @@ function readHermesUsageEvents({ sinceMs = 0 } = {}) {
   return hermesRowsToEvents(readHermesSessionRows(HERMES_STATE_DB), { sinceMs });
 }
 
+// ─── Goose: numeric usage ledger (messages are never queried) ───────────────
+function gooseDatabaseCandidates() {
+  const candidates = [];
+  const add = (path) => {
+    if (path && !candidates.includes(path)) candidates.push(path);
+  };
+  const root = process.env.GOOSE_PATH_ROOT;
+  if (root && isAbsolute(root)) add(join(root, 'data', 'sessions', 'sessions.db'));
+  add(join(homedir(), '.local', 'share', 'goose', 'sessions', 'sessions.db'));
+  add(join(homedir(), 'Library', 'Application Support', 'Block', 'goose', 'sessions', 'sessions.db'));
+  add(join(homedir(), 'Library', 'Application Support', 'Block', 'goose', 'data', 'sessions', 'sessions.db'));
+  add(join(homedir(), 'Library', 'Application Support', 'goose', 'sessions', 'sessions.db'));
+  if (process.env.APPDATA) add(join(process.env.APPDATA, 'Block', 'goose', 'data', 'sessions', 'sessions.db'));
+  return candidates;
+}
+
+function readGooseUsageRows(dbPath) {
+  if (!existsSync(dbPath)) return [];
+  try {
+    const sessionSchema = JSON.parse(execFileSync('sqlite3', [
+      '-readonly', '-json', dbPath, 'PRAGMA table_info(sessions)',
+    ], { encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] }) || '[]');
+    const ledgerSchema = JSON.parse(execFileSync('sqlite3', [
+      '-readonly', '-json', dbPath, 'PRAGMA table_info(usage_ledger)',
+    ], { encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] }) || '[]');
+    const query = buildGooseUsageQuery(
+      sessionSchema.map((column) => column.name).filter(Boolean),
+      ledgerSchema.map((column) => column.name).filter(Boolean),
+    );
+    const rows = JSON.parse(execFileSync('sqlite3', ['-readonly', '-json', dbPath, query], {
+      encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'],
+    }) || '[]');
+    return Array.isArray(rows) ? rows : [];
+  } catch {
+    // sqlite3 CLI unavailable or incompatible — try Node's built-in SQLite.
+  }
+  try {
+    const { DatabaseSync } = require('node:sqlite');
+    const db = new DatabaseSync(dbPath, { readOnly: true });
+    const sessionColumns = db.prepare('PRAGMA table_info(sessions)').all().map((column) => column.name).filter(Boolean);
+    const ledgerColumns = db.prepare('PRAGMA table_info(usage_ledger)').all().map((column) => column.name).filter(Boolean);
+    const rows = db.prepare(buildGooseUsageQuery(sessionColumns, ledgerColumns)).all();
+    db.close();
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+function readGooseUsageEvents({ sinceMs = 0 } = {}) {
+  const events = [];
+  for (const dbPath of gooseDatabaseCandidates()) {
+    events.push(...gooseRowsToEvents(readGooseUsageRows(dbPath), { sinceMs }));
+  }
+  return events;
+}
+
 // ─── OpenHuman: active workspace cost ledger ────────────────────────────────
 // Discovery reads only OpenHuman's two tiny active-path markers, then the
 // numeric costs.jsonl ledger. It never opens memory, transcript, run-journal,
@@ -4317,6 +4382,9 @@ function collectLocalUsageEvents({ maxAgeMs, toolFilter = null, providerFilter =
   if (!toolFilter || toolFilter === 'hermes') {
     addEvents(readHermesUsageEvents({ sinceMs }));
   }
+  if (!toolFilter || toolFilter === 'goose') {
+    addEvents(readGooseUsageEvents({ sinceMs }));
+  }
   if (!toolFilter || toolFilter === 'openhuman') {
     addEvents(collectOpenHumanUsageEvents({ sinceMs }));
   }
@@ -4348,7 +4416,7 @@ function collectLocalUsageEvents({ maxAgeMs, toolFilter = null, providerFilter =
 
     // A tool-reported billed cost (e.g. Hermes actual_cost_usd) wins over
     // our estimate.
-    if (Number(event.totalCost) > 0) continue;
+    if (Number(event.totalCost) > 0 || event.costRecorded === true) continue;
     const disjoint = event.cachedDisjoint === false
       ? false
       : event.provider === 'anthropic' || event.cachedDisjoint === true;
@@ -4358,7 +4426,11 @@ function collectLocalUsageEvents({ maxAgeMs, toolFilter = null, providerFilter =
       event.outputTokens || 0,
       event.cachedTokens || 0,
       event.cacheCreationTokens || 0,
-      { cachedIncludedInInput: !disjoint }
+      {
+        cachedIncludedInInput: !disjoint,
+        cacheCreationIncludedInInput: event.cacheCreationIncludedInInput === true,
+        timestamp: event.timestamp,
+      }
     );
     event.inputCost = cost.inputCost;
     event.outputCost = cost.outputCost;
@@ -6440,7 +6512,7 @@ function printHelp() {
     tokimeter status             Show proxy status and cost summary
     tokimeter report             Zero-setup usage report from local logs (no proxy needed)
     tokimeter report --days=7 --tool claude --json
-    tokimeter report --tool opencode     Scope to one tool (also: claude, codex, grok, hermes, openhuman, cline, copilot, cursor)
+    tokimeter report --tool opencode     Scope to one tool (also: claude, codex, grok, goose, hermes, openhuman, cline, copilot, cursor)
     tokimeter report --provider xai      Roll up one provider across tools (for example Grok Build + Hermes xAI OAuth)
     tokimeter export --days=30 > usage.json   JSON export (loadable by the Pro dashboard)
     tokimeter report --md > report.md         Shareable Markdown report (also --html)

--- a/ts/packages/proxy/src/parsers.js
+++ b/ts/packages/proxy/src/parsers.js
@@ -912,6 +912,147 @@ export function hermesRowsToEvents(rows, { sinceMs = 0 } = {}) {
   return events;
 }
 
+// ─── Goose usage ledger → usage events ─────────────────────────────────────
+// Goose 1.10+ stores per-call numeric usage in usage_ledger. Tokimeter never
+// queries the messages table: prompts, responses, and tool output stay out of
+// scope. Older/migrated sessions with no ledger rows fall back to the numeric
+// accumulated totals on sessions, so the two sources cannot double-count.
+
+function gooseColumn(columns, name, fallback = 'NULL', table = '') {
+  const available = new Set(Array.from(columns || [], (column) => String(column)));
+  return available.has(name) ? `${table ? `${table}.` : ''}"${name}"` : fallback;
+}
+
+export function buildGooseUsageQuery(sessionColumns = [], ledgerColumns = []) {
+  const s = (name, fallback = 'NULL') => gooseColumn(sessionColumns, name, fallback, 's');
+  const u = (name, fallback = 'NULL') => gooseColumn(ledgerColumns, name, fallback, 'u');
+  const sessionModel = sessionColumns.includes('model_config_json')
+    ? `CASE WHEN json_valid(${s('model_config_json')}) THEN json_extract(${s('model_config_json')}, '$.model_name') END`
+    : "''";
+  const sessionTimestamp = sessionColumns.includes('updated_at')
+    ? `COALESCE(CAST(strftime('%s', ${s('updated_at')}) AS INTEGER), CAST(${s('updated_at')} AS INTEGER), 0)`
+    : '0';
+  const hasLedger = ledgerColumns.includes('session_id') && sessionColumns.includes('id');
+
+  const sessionSelect = `SELECT
+    'session' AS record_kind,
+    ${s('id', "''")} AS record_id,
+    ${s('id', "''")} AS session_id,
+    ${sessionTimestamp} AS created_timestamp,
+    COALESCE(${sessionModel}, 'unknown') AS model,
+    ${s('provider_name', "''")} AS provider_name,
+    ${s('accumulated_input_tokens', s('input_tokens', '0'))} AS input_tokens,
+    ${s('accumulated_output_tokens', s('output_tokens', '0'))} AS output_tokens,
+    ${s('accumulated_total_tokens', s('total_tokens', '0'))} AS total_tokens,
+    ${s('accumulated_cache_read_tokens', s('cache_read_tokens', '0'))} AS cache_read_tokens,
+    ${s('accumulated_cache_write_tokens', s('cache_write_tokens', '0'))} AS cache_write_tokens,
+    ${s('accumulated_cost')} AS cost,
+    'estimated' AS cost_source,
+    0 AS is_compaction,
+    ${s('working_dir')} AS working_dir,
+    ${s('session_type', "''")} AS session_type,
+    ${s('parent_session_id')} AS parent_session_id
+  FROM sessions s${hasLedger ? ` WHERE NOT EXISTS (SELECT 1 FROM usage_ledger u WHERE u.session_id = s.id)` : ''}`;
+
+  if (!hasLedger) return sessionSelect;
+  return `SELECT
+    'ledger' AS record_kind,
+    ${u('id', "''")} AS record_id,
+    ${u('session_id', "''")} AS session_id,
+    ${u('created_timestamp', '0')} AS created_timestamp,
+    COALESCE(${u('model')}, ${sessionModel}, 'unknown') AS model,
+    ${s('provider_name', "''")} AS provider_name,
+    ${u('input_tokens', '0')} AS input_tokens,
+    ${u('output_tokens', '0')} AS output_tokens,
+    ${u('total_tokens', '0')} AS total_tokens,
+    ${u('cache_read_tokens', '0')} AS cache_read_tokens,
+    ${u('cache_write_tokens', '0')} AS cache_write_tokens,
+    ${u('cost')} AS cost,
+    ${u('cost_source')} AS cost_source,
+    ${u('is_compaction', '0')} AS is_compaction,
+    ${s('working_dir')} AS working_dir,
+    ${s('session_type', "''")} AS session_type,
+    ${s('parent_session_id')} AS parent_session_id
+  FROM usage_ledger u JOIN sessions s ON s.id = u.session_id
+  UNION ALL
+  ${sessionSelect}`;
+}
+
+function gooseProviderFor(providerName, model) {
+  const direct = String(providerName || '').trim().toLowerCase();
+  const known = {
+    anthropic: 'anthropic', openai: 'openai', google: 'google', gemini: 'google',
+    xai: 'xai', deepseek: 'deepseek', mistral: 'mistral', zai: 'zai',
+  };
+  if (known[direct]) return known[direct];
+  const m = String(model || '').toLowerCase().split('/').pop();
+  if (m.startsWith('claude')) return 'anthropic';
+  if (m.startsWith('gemini')) return 'google';
+  if (m.startsWith('grok') || m.startsWith('composer')) return 'xai';
+  if (m.startsWith('deepseek')) return 'deepseek';
+  if (m.startsWith('mistral') || m.startsWith('ministral') || m.startsWith('codestral')) return 'mistral';
+  if (m.startsWith('glm')) return 'zai';
+  if (m.startsWith('gpt') || /^o\d/.test(m)) return 'openai';
+  return direct || 'unknown';
+}
+
+export function gooseRowsToEvents(rows, { sinceMs = 0 } = {}) {
+  const events = [];
+  for (const row of rows || []) {
+    const rawTimestamp = Number(row.created_timestamp) || 0;
+    const timestamp = rawTimestamp > 10_000_000_000 ? rawTimestamp : rawTimestamp * 1000;
+    if (!timestamp || (sinceMs && timestamp < sinceMs)) continue;
+    const inputTokens = Math.max(0, Number(row.input_tokens) || 0);
+    const outputTokens = Math.max(0, Number(row.output_tokens) || 0);
+    const cachedTokens = Math.max(0, Number(row.cache_read_tokens) || 0);
+    const cacheCreationTokens = Math.max(0, Number(row.cache_write_tokens) || 0);
+    const numericCost = Number(row.cost);
+    const totalCost = Math.max(0, numericCost || 0);
+    if (!(inputTokens || outputTokens || cachedTokens || cacheCreationTokens || totalCost)) continue;
+
+    const model = String(row.model || 'unknown');
+    const providerName = String(row.provider_name || '').trim().toLowerCase();
+    const costSource = String(row.cost_source || '').trim().toLowerCase();
+    const reported = costSource === 'provider_reported';
+    const costRecorded = row.cost !== null && row.cost !== undefined
+      && Number.isFinite(numericCost) && numericCost >= 0
+      && ['provider_reported', 'estimated', 'carried_forward'].includes(costSource);
+    const recordKind = row.record_kind === 'ledger' ? 'ledger' : 'session';
+    const isSubagent = String(row.session_type || '').toLowerCase() === 'sub_agent';
+    events.push({
+      timestamp,
+      provider: gooseProviderFor(providerName, model),
+      model,
+      inputTokens,
+      outputTokens,
+      cachedTokens,
+      cacheCreationTokens,
+      // Goose documents both cache buckets as subsets of input_tokens.
+      cachedDisjoint: false,
+      cacheCreationIncludedInInput: true,
+      ended: true,
+      latencyMs: 0,
+      success: true,
+      tool: 'goose',
+      source: `goose-${recordKind}`,
+      confidence: recordKind === 'ledger' ? 'exact' : 'imported',
+      pricingConfidence: costRecorded ? (reported ? 'reported' : 'estimated') : getPricingSource(model).confidence,
+      ...(costRecorded ? { totalCost, costSource, costRecorded: true } : {}),
+      ...(providerName ? { billingProvider: providerName } : {}),
+      ...(row.working_dir ? { cwd: String(row.working_dir) } : {}),
+      sessionId: String(row.session_id || ''),
+      externalId: `goose-${recordKind}:${row.record_id || `${row.session_id}:${timestamp}`}`,
+      note: recordKind === 'ledger'
+        ? 'Imported from Goose numeric usage ledger; message content was not read.'
+        : 'Imported from Goose numeric session totals; message content was not read.',
+      ...(Number(row.is_compaction) ? { effort: 'compaction' } : {}),
+      ...(isSubagent ? { role: 'worker' } : {}),
+      ...(row.parent_session_id ? { parentSessionId: String(row.parent_session_id) } : {}),
+    });
+  }
+  return events;
+}
+
 // ─── Delegation report (director vs worker economics) ───────────────────────
 // Attribution sources, per tool (see docs/BUILD_PLAN.md coverage matrix):
 //   claude-code — per-turn: events with role='worker' are subagent turns;

--- a/ts/test/parsers.test.js
+++ b/ts/test/parsers.test.js
@@ -15,6 +15,8 @@ import {
   analyzeLogFileFormat,
   buildHermesSessionQuery,
   hermesRowsToEvents,
+  buildGooseUsageQuery,
+  gooseRowsToEvents,
   readClaudeAgentActivity,
   classifyCodexRateLimitWindows,
   buildDelegationReport,
@@ -637,6 +639,71 @@ test('hermes: preserves xAI OAuth billing path without account identity', () => 
   assert.equal(event.accessPath, 'xAI OAuth (subscription)');
   assert.equal(event.email, undefined);
   assert.equal(event.accountId, undefined);
+});
+
+test('goose query reads only numeric ledger/session metadata and avoids double counting', () => {
+  const sessionColumns = [
+    'id', 'working_dir', 'updated_at', 'session_type', 'accumulated_input_tokens',
+    'accumulated_output_tokens', 'accumulated_total_tokens',
+    'accumulated_cache_read_tokens', 'accumulated_cache_write_tokens',
+    'accumulated_cost', 'provider_name', 'model_config_json', 'parent_session_id',
+  ];
+  const ledgerColumns = [
+    'id', 'session_id', 'created_timestamp', 'model', 'input_tokens',
+    'output_tokens', 'total_tokens', 'cache_read_tokens', 'cache_write_tokens',
+    'cost', 'cost_source', 'is_compaction',
+  ];
+  const query = buildGooseUsageQuery(sessionColumns, ledgerColumns);
+  assert.match(query, /FROM usage_ledger u JOIN sessions s/);
+  assert.match(query, /NOT EXISTS \(SELECT 1 FROM usage_ledger/);
+  assert.match(query, /json_extract\([^]*'\$\.model_name'\)/);
+  assert.doesNotMatch(query, /\bmessages\b|content_json|description|recipe_json/i);
+});
+
+test('goose rows preserve per-model/cache usage and cost provenance without content', () => {
+  const events = gooseRowsToEvents([
+    {
+      record_kind: 'ledger', record_id: 41, session_id: 'goose-session-1',
+      created_timestamp: 1787306400, model: 'anthropic/claude-sonnet-5',
+      provider_name: 'openrouter', input_tokens: 1200, output_tokens: 300,
+      total_tokens: 1500, cache_read_tokens: 800, cache_write_tokens: 50,
+      cost: 0.0123, cost_source: 'provider_reported', is_compaction: 0,
+      working_dir: '/Users/demo/work/api', session_type: 'user', parent_session_id: null,
+      content_json: 'must not be copied',
+    },
+    {
+      record_kind: 'session', record_id: 'old-session', session_id: 'old-session',
+      created_timestamp: 1787306500, model: 'gpt-5.6-luna', provider_name: 'openai',
+      input_tokens: 500, output_tokens: 50, total_tokens: 550,
+      cache_read_tokens: 0, cache_write_tokens: 0, cost: 0.0002,
+      cost_source: 'estimated', is_compaction: 0, working_dir: '/Users/demo/work/api',
+      session_type: 'sub_agent', parent_session_id: 'goose-session-1',
+    },
+    {
+      record_kind: 'ledger', record_id: 42, session_id: 'goose-session-free',
+      created_timestamp: 1787306600, model: 'local-model', provider_name: 'ollama',
+      input_tokens: 100, output_tokens: 10, total_tokens: 110,
+      cache_read_tokens: 0, cache_write_tokens: 0, cost: 0,
+      cost_source: 'provider_reported', is_compaction: 0,
+      working_dir: '/Users/demo/work/api', session_type: 'user', parent_session_id: null,
+    },
+  ]);
+  assert.equal(events.length, 3);
+  assert.equal(events[0].tool, 'goose');
+  assert.equal(events[0].provider, 'anthropic');
+  assert.equal(events[0].billingProvider, 'openrouter');
+  assert.equal(events[0].cachedDisjoint, false);
+  assert.equal(events[0].cacheCreationIncludedInInput, true);
+  assert.equal(events[0].pricingConfidence, 'reported');
+  assert.equal(events[0].totalCost, 0.0123);
+  assert.equal(events[0].content_json, undefined);
+  assert.equal(events[0].prompt, undefined);
+  assert.equal(events[1].confidence, 'imported');
+  assert.equal(events[1].role, 'worker');
+  assert.equal(events[1].parentSessionId, 'goose-session-1');
+  assert.equal(events[2].totalCost, 0);
+  assert.equal(events[2].costRecorded, true);
+  assert.equal(events[2].pricingConfidence, 'reported');
 });
 
 test('delegation report: claude per-turn and hermes per-session splits', () => {

--- a/ts/test/pricing.test.js
+++ b/ts/test/pricing.test.js
@@ -256,10 +256,10 @@ test('report JSON discovers OpenHuman active-user costs and preserves cost prove
   assert.doesNotMatch(output, new RegExp(userId));
 });
 
-test('corrected 2026-08-04 rates match published pricing, aliases included', async () => {
+test('corrected rates match published pricing, aliases included', async () => {
   const { getPrice } = await import(pathToFileURL(PRICING).href);
 
-  // Google, short-context tier per ai.google.dev, verified 2026-08-04.
+  // Google, short-context tier per ai.google.dev, verified 2026-08-21.
   assert.deepEqual(
     [getPrice('gemini-2.5-flash').input, getPrice('gemini-2.5-flash').output],
     [0.30, 2.50],
@@ -272,8 +272,12 @@ test('corrected 2026-08-04 rates match published pricing, aliases included', asy
   // The pre-correction names stay resolvable as aliases.
   assert.equal(getPrice('gemini-3-flash').model, 'gemini-3.5-flash');
   assert.equal(getPrice('gemini-3-pro').model, 'gemini-3.1-pro-preview');
+  assert.deepEqual(
+    [getPrice('gemini-3.6-flash').input, getPrice('gemini-3.6-flash').output],
+    [0.75, 3.75],
+  );
 
-  // Mistral, per mistral.ai/pricing/api, verified 2026-08-04. The floating
+  // Mistral, per mistral.ai/pricing/api, verified 2026-08-21. The floating
   // -latest aliases must resolve to the generation they actually point at.
   assert.equal(getPrice('mistral-large-latest').model, 'mistral-large-3');
   assert.deepEqual(
@@ -283,12 +287,36 @@ test('corrected 2026-08-04 rates match published pricing, aliases included', asy
   assert.equal(getPrice('mistral-medium-latest').input, 1.50);
   // Cache read is Mistral's published 90% discount, not zero.
   assert.equal(getPrice('mistral-small-4').cached, 0.015);
+  assert.equal(getPrice('codestral-latest').model, 'codestral');
+  assert.deepEqual([getPrice('codestral').input, getPrice('codestral').output], [0.30, 0.90]);
 
-  // DeepSeek, per api-docs.deepseek.com, verified 2026-08-04.
+  // DeepSeek off-peak base rates, per api-docs.deepseek.com, verified 2026-08-21.
   assert.deepEqual(
     [getPrice('deepseek-v4-pro').input, getPrice('deepseek-v4-pro').output],
-    [0.435, 0.87],
+    [0.66, 1.98],
   );
+});
+
+test('DeepSeek pricing selects the published UTC peak tier from the event timestamp', async () => {
+  const { priceCall } = await import(pathToFileURL(PRICING).href);
+  const offPeak = priceCall('deepseek-v4-flash', 1_000_000, 1_000_000, 0, 0, {
+    timestamp: Date.parse('2026-08-21T12:00:00Z'),
+  });
+  const peak = priceCall('deepseek-v4-flash', 1_000_000, 1_000_000, 0, 0, {
+    timestamp: Date.parse('2026-08-21T06:30:00Z'),
+  });
+  assert.equal(offPeak.totalCost, 0.88);
+  assert.equal(peak.totalCost, 1.76);
+  assert.equal(peak.price.pricingTier, 'peak');
+});
+
+test('inclusive cache-write ledgers do not double count cache creation tokens', async () => {
+  const { priceCall } = await import(pathToFileURL(PRICING).href);
+  const priced = priceCall('claude-sonnet-5', 1_000_000, 0, 200_000, 100_000, {
+    cachedIncludedInInput: true,
+    cacheCreationIncludedInInput: true,
+  });
+  assert.equal(priced.totalCost, 1.69);
 });
 
 test('models without a sourceable published rate stay unpriced', async () => {
@@ -301,9 +329,9 @@ test('models without a sourceable published rate stay unpriced', async () => {
     assert.equal(getPrice(model), null, `${model} must not resolve to a built-in price`);
   }
 
-  // Models delisted from their provider's pricing page go with them, rather
-  // than lingering at a rate that can no longer be verified.
-  for (const model of ['deepseek-v3', 'deepseek-r1', 'gemini-1.5-flash', 'codestral']) {
+  // Unsourced models stay unpriced. Codestral is intentionally absent here:
+  // Mistral lists it again and Tokimeter now carries that published rate.
+  for (const model of ['deepseek-v3', 'deepseek-r1', 'gemini-1.5-flash']) {
     assert.equal(getPrice(model), null, `${model} must not resolve to a built-in price`);
   }
 });
@@ -319,7 +347,7 @@ test('every downgrade suggestion points at a model that is actually priced', asy
   }
 });
 
-test('re-verified 2026-08-04 rates match published pricing', async () => {
+test('re-verified active rates match published pricing', async () => {
   const { getPrice } = await import(pathToFileURL(PRICING).href);
 
   // OpenAI, per developers.openai.com. These four were wrong before the
@@ -334,6 +362,9 @@ test('re-verified 2026-08-04 rates match published pricing', async () => {
   assert.equal(getPrice('grok-4.5').cached, 0.30);
   assert.equal(getPrice('grok-4.3').cached, 0.20);
   assert.equal(getPrice('grok-build').cached, 0.20);
+  assert.deepEqual([getPrice('grok-4.6').input, getPrice('grok-4.6').output], [2.00, 6.00]);
+  assert.equal(getPrice('grok-4.6').cached, 0.50);
+  assert.deepEqual([getPrice('glm-5.3').input, getPrice('glm-5.3').output], [1.40, 4.40]);
 
   // Anthropic re-verified with no change, including the introductory rate
   // still in effect through 2026-08-31.


### PR DESCRIPTION
## Summary\n- add zero-setup Goose usage tracking from its local numeric SQLite ledger without querying message content\n- fall back to older session totals only when a session has no ledger rows\n- refresh official model pricing, including DeepSeek time tiers, Gemini 3.6 promotional pricing, Codestral, Grok 4.6, and current GLM models\n- keep JavaScript and Python pricing behavior aligned\n\n## Verification\n- full Node test suite: 143 passed\n- targeted parser/pricing tests: 110 passed\n- Python tests: 31 passed\n- pricing table check passed\n- privacy CI and pre-commit package gates passed\n- synthetic current-schema Goose SQLite query passed\n\nCloses #4