### PR TITLE
Prepare npm 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The versioning is [semver](https://semver.org); pre-1.0, minor versions may add 
 
 ## Unreleased
 
+## 0.7.0 — 2026-08-27
+
 ### Added
 
 - Add `tokimeter advisor`, a deterministic local shortlist of ranked actions

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>
-  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="374" height="40" alt="npm v0.6.0, release v0.6.0, MIT license, Node 18+" align="right" hspace="2"></a>
+  <a href="https://github.com/toshipepe/tokimeter/releases/latest"><img src="readme-badges.svg" width="374" height="40" alt="npm v0.7.0, release v0.7.0, MIT license, Node 18+" align="right" hspace="2"></a>
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="readme-wordmark-dark.svg">
     <img src="readme-wordmark.svg" width="190" height="48" alt="Tokimeter">

--- a/readme-badges.svg
+++ b/readme-badges.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="374" height="40" viewBox="0 0 374 40" role="img" aria-label="npm v0.6.0, release v0.6.0, MIT license, Node 18+">
-  <title>npm v0.6.0 · release v0.6.0 · MIT · Node 18+</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="374" height="40" viewBox="0 0 374 40" role="img" aria-label="npm v0.7.0, release v0.7.0, MIT license, Node 18+">
+  <title>npm v0.7.0 · release v0.7.0 · MIT · Node 18+</title>
   <defs>
     <clipPath id="npm">
       <rect x="0" y="12" width="90" height="20" rx="3"/>
@@ -34,9 +34,9 @@
 
   <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
     <text x="18" y="26" text-anchor="middle">npm</text>
-    <text x="63" y="26" text-anchor="middle">v0.6.0</text>
+    <text x="63" y="26" text-anchor="middle">v0.7.0</text>
     <text x="124" y="26" text-anchor="middle">release</text>
-    <text x="177" y="26" text-anchor="middle">v0.6.0</text>
+    <text x="177" y="26" text-anchor="middle">v0.7.0</text>
     <text x="236" y="26" text-anchor="middle">License</text>
     <text x="277" y="26" text-anchor="middle">MIT</text>
     <text x="321" y="26" text-anchor="middle">node</text>

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -58,7 +58,7 @@
     },
     "packages/proxy": {
       "name": "tokimeter",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "bin": {
         "tm": "src/cli.js",

--- a/ts/packages/proxy/package.json
+++ b/ts/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokimeter",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Local-first usage & cost meter for AI coding agents (Claude Code, Codex, Cursor, Grok Build, Hermes, opencode, Cline, Copilot CLI). Inline status-line HUDs, zero-setup reports, 5h-window limits, budgets — no telemetry.",
   "type": "module",
   "main": "src/server.js",


### PR DESCRIPTION
## Summary
- set the Tokimeter package and lockfile version to 0.7.0
- date the Goose, pricing, and Advisor changelog entries
- refresh README release badges for 0.7.0

## Verification
- npm test (148 passed)
- python3 tests/test_basic.py (31 passed)
- node scripts/privacy-check.mjs --ci
- node scripts/privacy-check.mjs --precommit
- npm pack --dry-run (12 reviewed files)
- author is ToshiPepe with no author.email
- no install or postinstall scripts